### PR TITLE
Make MicronautRequestHandler friendly to Spock mocks (fixes #4)

### DIFF
--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -31,17 +31,19 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
 
     @Override
     public final O handleRequest(I input, Context context) {
-        ApplicationContext applicationContext = buildApplicationContext(context);
-        startEnvironment(applicationContext);
+        if (applicationContext == null) {
+            applicationContext = buildApplicationContext(context);
+        }
+        if (context != null) {
+            registerContextBeans(context, applicationContext);
+        }
         return applicationContext.inject(this).execute(input);
     }
 
     @Override
     protected ApplicationContext buildApplicationContext(Context context) {
-        ApplicationContext applicationContext = super.buildApplicationContext(context);
-        if (context != null) {
-            registerContextBeans(context, applicationContext);
-        }
+        applicationContext = super.buildApplicationContext(context);
+        startEnvironment(applicationContext);
         return applicationContext;
     }
 

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandler.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandler.groovy
@@ -1,0 +1,14 @@
+package io.micronaut.function.aws
+
+import javax.inject.Inject
+
+class SquareHandler extends MicronautRequestHandler<Integer, Integer> {
+
+    @Inject
+    SquareService squareService
+
+    @Override
+    Integer execute(Integer input) {
+        return squareService.square(input)
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandlerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandlerSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.function.aws
+
+import com.amazonaws.services.lambda.runtime.ClientContext
+import com.amazonaws.services.lambda.runtime.CognitoIdentity
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import io.micronaut.context.ApplicationContext
+import org.spockframework.mock.MockUtil
+import spock.lang.Shared
+import spock.lang.Specification
+
+class SquareHandlerSpec extends Specification {
+
+    @Shared
+    MockUtil mockUtil = new MockUtil()
+
+    @Shared
+    Context lambdaCtx = Mock(Context) {
+        getLogger() >> Mock(LambdaLogger)
+        getClientContext() >> Mock(ClientContext)
+        getIdentity() >> Mock(CognitoIdentity)
+    }
+
+    def "test using detached mock"() {
+        given:
+        def handler = new SquareHandler()
+        def appCtx = handler.buildApplicationContext(lambdaCtx)
+        def squareService = appCtx.getBean(SquareService)
+        assert mockUtil.isMock(squareService)
+        mockUtil.attachMock(squareService, this)
+
+        when:
+        def result = handler.handleRequest(2, lambdaCtx)
+
+        then:
+        squareService.square(_) >> 4
+        result == 4
+
+        cleanup:
+        mockUtil.detachMock(squareService)
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/SquareService.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/SquareService.groovy
@@ -1,0 +1,5 @@
+package io.micronaut.function.aws
+
+interface SquareService {
+    int square(int input)
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/SquareServiceMockFactory.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/SquareServiceMockFactory.groovy
@@ -1,0 +1,17 @@
+package io.micronaut.function.aws
+
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.Factory
+import spock.mock.DetachedMockFactory
+
+import javax.inject.Singleton
+
+@Factory
+class SquareServiceMockFactory {
+
+    @Bean
+    @Singleton
+    SquareService mockEchoService() {
+        return new DetachedMockFactory().Mock(SquareService)
+    }
+}


### PR DESCRIPTION
Proposed fix for #4, refactoring `MicronautRequestHandler` to allow testing via inject Spock mocks.  Includes a test to demonstrate and verify that the pattern now works.