### PR TITLE
Update awsCredentialsProvider.adoc

### DIFF
--- a/src/main/docs/guide/awsCredentialsProvider.adoc
+++ b/src/main/docs/guide/awsCredentialsProvider.adoc
@@ -1,4 +1,4 @@
-When working with AWS SDK, you may need to provide a `com.amazonaws.auth.AWSCredentialsProvider`. To ease that this module provides a utility class: api::configuration.aws.EnvironmentAWSCredentialsProvider[].
+When working with AWS SDK, you may need to provide a `com.amazonaws.auth.AWSCredentialsProvider`. To ease that this module provides a utility class: api:configuration.aws.EnvironmentAWSCredentialsProvider[].
 
 For example the following snippet show how you may configure a S3 Client if you set two environment variables:
 


### PR DESCRIPTION
There is an extraneous colon in front of configuration in the URL as shown:

<a href="../api/io/micronaut/:configuration/aws/EnvironmentAWSCredentialsProvider.html">EnvironmentAWSCredentialsProvider</a>

yielding a 404, file not found server response.

I hope my proposed change remedies this.

Mike.