### PR TITLE
Check whether the route result is a Single

### DIFF
--- a/function-aws-api-proxy/build.gradle
+++ b/function-aws-api-proxy/build.gradle
@@ -19,5 +19,6 @@ dependencies {
     testCompile "io.micronaut:micronaut-inject-groovy"
     testCompile "io.micronaut:micronaut-security"
     testCompile 'io.micronaut:micronaut-views'
+    testCompile "io.projectreactor:reactor-core"
     testRuntime 'com.github.jknack:handlebars:4.1.2'
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -422,7 +422,12 @@ public final class MicronautLambdaContainerHandler
             return Flowable.just(containerResponse);
         }
         if (Publishers.isConvertibleToPublisher(result)) {
-            final Single<?> single = Publishers.convertPublisher(result, Single.class);
+            Single<?> single;
+            if (Publishers.isSingle(result.getClass())) {
+                single = Publishers.convertPublisher(result, Single.class);
+            } else {
+                single = Publishers.convertPublisher(result, Flowable.class).toList();
+            }
             return single.map((Function<Object, MutableHttpResponse<?>>) o -> {
                 if (!(o instanceof MicronautAwsProxyResponse)) {
                     ((MutableHttpResponse) containerResponse).body(o);

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/FluxSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/FluxSpec.groovy
@@ -1,0 +1,44 @@
+package io.micronaut.function.aws.proxy
+
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext
+import com.amazonaws.services.lambda.runtime.Context
+import io.micronaut.context.ApplicationContext
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import reactor.core.publisher.Flux
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class FluxSpec extends Specification {
+
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+            ApplicationContext.build()
+    )
+    @Shared Context lambdaContext = new MockLambdaContext()
+
+    void "test getAll method"() {
+        given:
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder("/users", HttpMethod.GET.toString())
+
+        when:
+        def response = handler.proxy(builder.build(), lambdaContext)
+
+        then:
+        response.statusCode == 200
+        response.body == '["Joe","Lewis"]'
+    }
+
+
+    @Controller("/users")
+    static class UserController {
+
+        @Get
+        Flux<String> getAll() {
+            return Flux.fromIterable(["Joe", "Lewis"])
+        }
+
+    }
+}


### PR DESCRIPTION
Otherwise, call `toList()` on the `Flowable`.

Fixes #51