### PR TITLE
Remove deprecated calls

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: ['1.8', '11.0.4']
+        java: ['1.8', '11']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v1
@@ -26,6 +26,14 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Build with Gradle
       run: ./gradlew check --parallel --continue
+    - name: Build and test alexa-hello-world-groovy
+      run: cd alexa-hello-world-groovy && ./gradlew check
+    - name: Build and test alexa-hello-world-java
+      run: cd alexa-hello-world-java && ./mvnw test
+    - name: Build and test alexa-hello-world-kotlin
+      run: cd alexa-hello-world-kotlin && ./gradlew check
+    - name: Build and test api-gateway-example
+      run: cd api-gateway-example && ./gradlew check
     - name: Publish to JFrog OSS
       if: success() && github.event_name == 'push' && matrix.java == '1.8'
       env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -27,13 +27,13 @@ jobs:
     - name: Build with Gradle
       run: ./gradlew check --parallel --continue
     - name: Build and test alexa-hello-world-groovy
-      run: cd alexa-hello-world-groovy && ./gradlew check
+      run: cd examples/alexa-hello-world-groovy && ./gradlew check
     - name: Build and test alexa-hello-world-java
-      run: cd alexa-hello-world-java && ./mvnw test
+      run: cd examples/alexa-hello-world-java && ./gradlew check
     - name: Build and test alexa-hello-world-kotlin
-      run: cd alexa-hello-world-kotlin && ./gradlew check
+      run: cd examples/alexa-hello-world-kotlin && ./gradlew check
     - name: Build and test api-gateway-example
-      run: cd api-gateway-example && ./gradlew check
+      run: cd examples/api-gateway-example && ./gradlew check
     - name: Publish to JFrog OSS
       if: success() && github.event_name == 'push' && matrix.java == '1.8'
       env:

--- a/aws-common/src/test/resources/logback.xml
+++ b/aws-common/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.configuration.aws" level="TRACE"/>
+</configuration>

--- a/examples/alexa-hello-world-groovy/build.gradle
+++ b/examples/alexa-hello-world-groovy/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'io.micronaut:micronaut-bom:1.1.0.M1'
+        mavenBom 'io.micronaut:micronaut-bom:1.2.10'
     }
 }
 
@@ -30,7 +30,7 @@ configurations {
 
 dependencies {
     compileOnly "io.micronaut:micronaut-validation"
-    compileOnly "io.micronaut:micronaut-inject-groovy:1.1.0.M1"
+    compileOnly "io.micronaut:micronaut-inject-groovy:1.2.10"
     compile "io.micronaut.aws:micronaut-function-aws-alexa:1.1.0.M2"
     compile "io.micronaut:micronaut-inject"
     compile "io.micronaut:micronaut-validation"
@@ -41,7 +41,7 @@ dependencies {
     testCompile("org.spockframework:spock-core:1.2-groovy-2.5") {
         exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
-    testCompile "io.micronaut:micronaut-inject-groovy:1.1.0.M1"
+    testCompile "io.micronaut:micronaut-inject-groovy:1.2.10"
     testCompile "io.micronaut.test:micronaut-test-spock"
 }
 

--- a/examples/alexa-hello-world-groovy/dependency-reduced-pom.xml
+++ b/examples/alexa-hello-world-groovy/dependency-reduced-pom.xml
@@ -175,7 +175,7 @@
   <properties>
     <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <micronaut.version>1.1.0.BUILD-SNAPSHOT</micronaut.version>
+    <micronaut.version>1.2.10</micronaut.version>
   </properties>
 </project>
 

--- a/examples/alexa-hello-world-java/dependency-reduced-pom.xml
+++ b/examples/alexa-hello-world-java/dependency-reduced-pom.xml
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-function-web</artifactId>
-      <version>1.1.0.BUILD-SNAPSHOT</version>
+      <version>1.2.10</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -109,13 +109,13 @@
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-inject-java</artifactId>
-      <version>1.1.0.BUILD-SNAPSHOT</version>
+      <version>1.2.10</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>5.3.1</version>
+      <version>5.5.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.3.1</version>
+      <version>5.5.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -151,7 +151,7 @@
     <dependency>
       <groupId>io.micronaut.test</groupId>
       <artifactId>micronaut-test-junit5</artifactId>
-      <version>1.0.1</version>
+      <version>1.1.2</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -175,7 +175,7 @@
   <properties>
     <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <micronaut.version>1.1.0.BUILD-SNAPSHOT</micronaut.version>
+    <micronaut.version>1.2.10</micronaut.version>
   </properties>
 </project>
 

--- a/examples/alexa-hello-world-java/pom.xml
+++ b/examples/alexa-hello-world-java/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>alex-hello-world-java</artifactId>
   <version>0.1</version>
   <properties>
-    <micronaut.version>1.1.0.BUILD-SNAPSHOT</micronaut.version>
+    <micronaut.version>1.2.10</micronaut.version>
     <jdk.version>1.8</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/examples/api-gateway-example/gradle.properties
+++ b/examples/api-gateway-example/gradle.properties
@@ -1,1 +1,1 @@
-micronaut_version=1.2.2
+micronaut_version=1.2.10

--- a/examples/api-gateway-example/settings.gradle
+++ b/examples/api-gateway-example/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name="example"
+rootProject.name="api-gateway-example"

--- a/examples/api-gateway-example/src/main/java/example/StreamLambdaHandler.java
+++ b/examples/api-gateway-example/src/main/java/example/StreamLambdaHandler.java
@@ -7,10 +7,12 @@ import io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler;
 import java.io.*;
 
 public class StreamLambdaHandler implements RequestStreamHandler {
-    private static MicronautLambdaContainerHandler handler; // <1>
-    static {
+
+    private MicronautLambdaContainerHandler handler;
+
+    public StreamLambdaHandler() {
         try {
-            handler = new MicronautLambdaContainerHandler();
+            handler = new MicronautLambdaContainerHandler(); // <1>
         } catch (ContainerInitializationException e) {
             // if we fail here. We re-throw the exception to force another cold start
             e.printStackTrace();

--- a/examples/api-gateway-example/src/main/java/example/StreamLambdaHandler.java
+++ b/examples/api-gateway-example/src/main/java/example/StreamLambdaHandler.java
@@ -10,7 +10,7 @@ public class StreamLambdaHandler implements RequestStreamHandler {
     private static MicronautLambdaContainerHandler handler; // <1>
     static {
         try {
-            handler = MicronautLambdaContainerHandler.getAwsProxyHandler();
+            handler = new MicronautLambdaContainerHandler();
         } catch (ContainerInitializationException e) {
             // if we fail here. We re-throw the exception to force another cold start
             e.printStackTrace();

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/BodySpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/BodySpec.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class BodySpec extends Specification {
 
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
                 ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ConsumesSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ConsumesSpec.groovy
@@ -17,7 +17,7 @@ import spock.lang.Specification
 
 class ConsumesSpec extends Specification {
 
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/CookiesSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/CookiesSpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 class CookiesSpec extends Specification {
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ErrorHandlerSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ErrorHandlerSpec.groovy
@@ -26,7 +26,7 @@ import javax.ws.rs.core.MediaType
 
 class ErrorHandlerSpec extends Specification {
 
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/FiltersSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/FiltersSpec.groovy
@@ -32,7 +32,7 @@ import javax.inject.Singleton
 import javax.validation.Valid
 
 class FiltersSpec extends Specification {
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/FluxSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/FluxSpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Specification
 
 class FluxSpec extends Specification {
 
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ParametersSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ParametersSpec.groovy
@@ -14,7 +14,7 @@ import spock.lang.Specification
 
 class ParametersSpec extends Specification {
 
-    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.build()
     )
     @Shared Context lambdaContext = new MockLambdaContext()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ResponseStatusSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ResponseStatusSpec.groovy
@@ -25,7 +25,7 @@ class ResponseStatusSpec extends Specification {
     void "test custom response status"() {
         given:
 
-        def handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+        def handler = new MicronautLambdaContainerHandler(
                 ApplicationContext.build()
         )
 
@@ -47,7 +47,7 @@ class ResponseStatusSpec extends Specification {
     void "test optional causes 404"() {
         given:
 
-            MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+            MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
                     ApplicationContext.build()
             )
 
@@ -67,7 +67,7 @@ class ResponseStatusSpec extends Specification {
     void "test null causes 404"() {
         given:
 
-            MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+            MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
                     ApplicationContext.build()
             )
 
@@ -87,7 +87,7 @@ class ResponseStatusSpec extends Specification {
     void "test void methods does not cause 404"() {
         given:
 
-            MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+            MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
                     ApplicationContext.build()
             )
 
@@ -107,7 +107,7 @@ class ResponseStatusSpec extends Specification {
     void "test constraint violation causes 400"() {
         given:
 
-            MicronautLambdaContainerHandler handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+            MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
                     ApplicationContext.build()
             )
 

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/HelloWorldMicronautTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/HelloWorldMicronautTest.java
@@ -75,7 +75,7 @@ public class HelloWorldMicronautTest {
     @BeforeClass
     public static void initializeServer() throws ContainerInitializationException {
         try {
-            handler = MicronautLambdaContainerHandler.getAwsProxyHandler();
+            handler = new MicronautLambdaContainerHandler();
         } catch (RuntimeException e) {
             e.printStackTrace();
             fail();

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/MicronautAwsProxyTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/MicronautAwsProxyTest.java
@@ -61,7 +61,7 @@ public class MicronautAwsProxyTest {
 
     static {
         try {
-            handler = MicronautLambdaContainerHandler.getAwsProxyHandler(
+            handler = new MicronautLambdaContainerHandler(
                         ApplicationContext.build()
                             .properties(CollectionUtils.mapOf(
                                     "micronaut.security.enabled", true,

--- a/function-aws/src/test/resources/logback.xml
+++ b/function-aws/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.function.aws" level="TRACE"/>
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,3 +6,6 @@ include 'function-aws-alexa'
 include 'function-aws-custom-runtime'
 include 'aws-common'
 
+file('examples').eachDir {
+    includeBuild "examples/${it.name}"
+}

--- a/src/main/docs/guide/lambda/apiProxy.adoc
+++ b/src/main/docs/guide/lambda/apiProxy.adoc
@@ -28,11 +28,11 @@ You can then implement a `RequestHandler` that handles the API proxy request:
 include::examples/api-gateway-example/src/main/java/example/StreamLambdaHandler.java[]
 ----
 
-<1> Micronaut is initialized in the static initializer
+<1> Micronaut is initialized in the constructor
 <2> The API Proxy Request is handled
 
 The api:function.aws.proxy.MicronautLambdaContainerHandler[] class is used to initialization Micronaut and handle the serverless requests.
 
-The `getAwsProxyHandler()` method also accepts a `ApplicationContextBuilder` instance which you can use to further customize application bootstrap.
+The `MicronautLambdaContainerHandler` constructor also accepts a `ApplicationContextBuilder` instance which you can use to further customize application bootstrap.
 
 TIP: See the https://github.com/micronaut-projects/micronaut-aws/tree/master/examples/api-gateway-example[Example Application] and associated https://github.com/micronaut-projects/micronaut-aws/blob/master/examples/api-gateway-example/README.md[README] for instructions on how to deploy locally using https://github.com/awslabs/aws-sam-cli[AWS SAM Local] and AWS Cloud Formation for production.


### PR DESCRIPTION
It also has a constructor-based approach for the sample `RequestStreamHandler` implementation. This fixes #36 