### PR TITLE
Use  LambdaRuntime.getLogger() to get LambdaLogger

### DIFF
--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/RuntimeContext.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/RuntimeContext.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.lambda.runtime.ClientContext;
 import com.amazonaws.services.lambda.runtime.CognitoIdentity;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.LambdaRuntime;
 import io.micronaut.http.HttpHeaders;
 
 import java.util.Calendar;
@@ -111,7 +112,7 @@ public class RuntimeContext implements Context {
 
     @Override
     public LambdaLogger getLogger() {
-        return null;
+        return LambdaRuntime.getLogger();
     }
 
 

--- a/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/RuntimeContextSpec.groovy
+++ b/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/RuntimeContextSpec.groovy
@@ -35,7 +35,7 @@ class RuntimeContextSpec extends Specification {
         !context.getClientContext()
         context.getRemainingTimeInMillis() == 5000
         context.getMemoryLimitInMB() == 512
-        !context.getLogger()
+        context.getLogger()
 
         where:
         requestId = "777e7e60-e583-483b-ae3a-2ed7c387823d"


### PR DESCRIPTION
Same way LambdaAppender gets hold of LambdaLogger:
https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-log4j2/src/main/java/com/amazonaws/services/lambda/runtime/log4j2/LambdaAppender.java#L28