### PR TITLE
feat: only handlers with same named or unqualified

### DIFF
--- a/aws-alexa/src/main/java/io/micronaut/aws/alexa/builders/DefaultAlexaSkillBuilder.java
+++ b/aws-alexa/src/main/java/io/micronaut/aws/alexa/builders/DefaultAlexaSkillBuilder.java
@@ -24,13 +24,21 @@ import com.amazon.ask.dispatcher.request.interceptor.ResponseInterceptor;
 import com.amazon.ask.model.RequestEnvelope;
 import com.amazon.ask.model.ResponseEnvelope;
 import io.micronaut.aws.alexa.conf.AlexaSkillConfiguration;
+import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.order.OrderUtil;
+import io.micronaut.inject.qualifiers.Qualifiers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.inject.Singleton;
+import javax.lang.model.element.AnnotationValue;
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Creates {@link AlexaSkill} by adding request and exception handlers (({@link RequestHandler}, {@link ExceptionHandler} beans) and interceptor beans ({@link RequestInterceptor} and {@link ResponseInterceptor}).
@@ -40,49 +48,174 @@ import java.util.Collection;
 @Singleton
 public class DefaultAlexaSkillBuilder implements AlexaSkillBuilder<RequestEnvelope, ResponseEnvelope> {
 
-    private final Collection<RequestHandler> requestHandlers;
-    private final Collection<ExceptionHandler> exceptionHandlers;
-    private final Collection<RequestInterceptor> requestInterceptors;
-    private final Collection<ResponseInterceptor> responseInterceptors;
+    private final Map<String, Collection<RequestHandler>> requestHandlersBySkillName = new HashMap<>();
+    private final Map<String, Collection<ExceptionHandler>> exceptionHandlersBySkillName = new HashMap<>();
+    private final Map<String, Collection<RequestInterceptor>> requestInterceptorsBySkillName = new HashMap<>();
+    private final Map<String, Collection<ResponseInterceptor>> responseInterceptorsBySkillName = new HashMap<>();
+
+    private final List<RequestHandler> unqualifiedRequestHandlers;
+    private final List<ExceptionHandler> unqualifiedExceptionHandlers;
+    private final List<RequestInterceptor> unqualifiedRequestInterceptors;
+    private final List<ResponseInterceptor> unqualifiedResponseInterceptors;
 
     /**
      *
-     * @param requestHandlers Request Handlers
-     * @param exceptionHandlers Exceptions Handlers
-     * @param requestInterceptors Request Interceptors
-     * @param responseInterceptors Response Interceptors
+     * @param alexaSkillConfigurations Alexa Skill Configurations
+     * @param applicationContext ApplicationContext
      */
-    public DefaultAlexaSkillBuilder(Collection<RequestHandler> requestHandlers,
-                                    Collection<ExceptionHandler> exceptionHandlers,
-                                    Collection<RequestInterceptor> requestInterceptors,
-                                    Collection<ResponseInterceptor> responseInterceptors) {
-        this.requestHandlers = requestHandlers;
-        this.exceptionHandlers = exceptionHandlers;
-        this.requestInterceptors = requestInterceptors;
-        this.responseInterceptors = responseInterceptors;
+    public DefaultAlexaSkillBuilder(Collection<AlexaSkillConfiguration> alexaSkillConfigurations,
+                                    ApplicationContext applicationContext) {
+
+        List<String> names = alexaSkillConfigurations.stream().map(AlexaSkillConfiguration::getName).collect(Collectors.toList());
+        for (String name : names) {
+            requestHandlersBySkillName.put(name, applicationContext.getBeansOfType(RequestHandler.class, Qualifiers.byName(name)));
+            exceptionHandlersBySkillName.put(name, applicationContext.getBeansOfType(ExceptionHandler.class, Qualifiers.byName(name)));
+            requestInterceptorsBySkillName.put(name, applicationContext.getBeansOfType(RequestInterceptor.class, Qualifiers.byName(name)));
+            responseInterceptorsBySkillName.put(name, applicationContext.getBeansOfType(ResponseInterceptor.class, Qualifiers.byName(name)));
+        }
+        Collection<RequestHandler> requestHandlers = applicationContext.getBeansOfType(RequestHandler.class);
+        List<RequestHandler> requestHandlersList = new ArrayList<>(requestHandlers);
+        for (String name : requestHandlersBySkillName.keySet()) {
+            requestHandlersList.removeAll(requestHandlersBySkillName.get(name));
+        }
+        this.unqualifiedRequestHandlers = requestHandlersList;
+
+        Collection<ExceptionHandler> exceptionHandlers = applicationContext.getBeansOfType(ExceptionHandler.class);
+        List<ExceptionHandler> exceptionHandlersList = new ArrayList<>(exceptionHandlers);
+        for (String name : exceptionHandlersBySkillName.keySet()) {
+            exceptionHandlersList.removeAll(exceptionHandlersBySkillName.get(name));
+        }
+        this.unqualifiedExceptionHandlers = exceptionHandlersList;
+
+        Collection<RequestInterceptor> requestInterceptors = applicationContext.getBeansOfType(RequestInterceptor.class);
+
+        List<RequestInterceptor> requestInterceptorsList = new ArrayList<>(requestInterceptors);
+        for (String name : requestInterceptorsBySkillName.keySet()) {
+            requestInterceptorsList.removeAll(requestInterceptorsBySkillName.get(name));
+        }
+        this.unqualifiedRequestInterceptors = requestInterceptorsList;
+
+        Collection<ResponseInterceptor> responseInterceptors = applicationContext.getBeansOfType(ResponseInterceptor.class);
+        List<ResponseInterceptor> responseInterceptorsList = new ArrayList<>(responseInterceptors);
+        for (String name : responseInterceptorsBySkillName.keySet()) {
+            responseInterceptorsList.removeAll(responseInterceptorsBySkillName.get(name));
+        }
+        this.unqualifiedResponseInterceptors = responseInterceptorsList;
     }
 
     @Nonnull
     @Override
      public AlexaSkill<RequestEnvelope, ResponseEnvelope> buildSkill(@Nonnull @NotNull SkillBuilder<?> skillBuilder,
                                                                      @Nullable AlexaSkillConfiguration alexaSkillConfiguration) {
-        requestHandlers
+
+        SkillBeans skillBeans = skillBeansByName(alexaSkillConfiguration != null ? alexaSkillConfiguration.getName() : null);
+        skillBeans.getRequestHandlers()
                 .stream()
                 .sorted(OrderUtil.COMPARATOR)
                 .forEach(skillBuilder::addRequestHandler);
-        exceptionHandlers
+
+        skillBeans.getExceptionHandlers()
                 .stream()
                 .sorted(OrderUtil.COMPARATOR)
                 .forEach(skillBuilder::addExceptionHandler);
-        requestInterceptors
+
+        skillBeans.getRequestInterceptors()
                 .stream()
                 .sorted(OrderUtil.COMPARATOR)
                 .forEach(skillBuilder::addRequestInterceptor);
-        responseInterceptors
+
+        skillBeans.getResponseInterceptors()
                 .stream()
                 .sorted(OrderUtil.COMPARATOR)
                 .forEach(skillBuilder::addResponseInterceptor);
-        return alexaSkillConfiguration == null ? skillBuilder.build() :
-                skillBuilder.withSkillId(alexaSkillConfiguration.getSkillId()).build();
+
+        if (alexaSkillConfiguration != null) {
+            skillBuilder = skillBuilder.withSkillId(alexaSkillConfiguration.getSkillId());
+        }
+        return skillBuilder.build();
+    }
+
+    private SkillBeans skillBeansByName(String name) {
+        List<RequestHandler> requestHandlers = new ArrayList<>();
+        requestHandlers.addAll(unqualifiedRequestHandlers);
+        if (name != null && requestHandlersBySkillName.containsKey(name)) {
+            requestHandlers.addAll(requestHandlersBySkillName.get(name));
+        }
+
+        List<ExceptionHandler> exceptionHandlers = new ArrayList<>();
+        exceptionHandlers.addAll(unqualifiedExceptionHandlers);
+        if (name != null && exceptionHandlersBySkillName.containsKey(name)) {
+            exceptionHandlers.addAll(exceptionHandlersBySkillName.get(name));
+        }
+
+        List<RequestInterceptor> requestInterceptors = new ArrayList<>();
+        requestInterceptors.addAll(unqualifiedRequestInterceptors);
+        if (name != null && requestInterceptorsBySkillName.containsKey(name)) {
+            requestInterceptors.addAll(requestInterceptorsBySkillName.get(name));
+        }
+
+        List<ResponseInterceptor> responseInterceptors = new ArrayList<>();
+        responseInterceptors.addAll(unqualifiedResponseInterceptors);
+        if (name != null && responseInterceptorsBySkillName.containsKey(name)) {
+            responseInterceptors.addAll(responseInterceptorsBySkillName.get(name));
+        }
+
+        return new SkillBeans(requestHandlers,
+                exceptionHandlers,
+                requestInterceptors,
+                responseInterceptors);
+    }
+
+    /**
+     * Beans for a particular Alexa Skills.
+     */
+    private static class SkillBeans {
+
+        private List<RequestHandler> requestHandlers;
+        private List<ExceptionHandler> exceptionHandlers;
+        private List<RequestInterceptor> requestInterceptors;
+        private List<ResponseInterceptor> responseInterceptors;
+
+        public SkillBeans(List<RequestHandler> requestHandlers,
+                          List<ExceptionHandler> exceptionHandlers,
+                          List<RequestInterceptor> requestInterceptors,
+                          List<ResponseInterceptor> responseInterceptors) {
+            this.requestHandlers = requestHandlers;
+            this.exceptionHandlers = exceptionHandlers;
+            this.requestInterceptors = requestInterceptors;
+            this.responseInterceptors = responseInterceptors;
+        }
+
+        public List<RequestHandler> getRequestHandlers() {
+            return requestHandlers;
+        }
+
+        public void setRequestHandlers(List<RequestHandler> requestHandlers) {
+            this.requestHandlers = requestHandlers;
+        }
+
+        public List<ExceptionHandler> getExceptionHandlers() {
+            return exceptionHandlers;
+        }
+
+        public void setExceptionHandlers(List<ExceptionHandler> exceptionHandlers) {
+            this.exceptionHandlers = exceptionHandlers;
+        }
+
+        public List<RequestInterceptor> getRequestInterceptors() {
+            return requestInterceptors;
+        }
+
+        public void setRequestInterceptors(List<RequestInterceptor> requestInterceptors) {
+            this.requestInterceptors = requestInterceptors;
+        }
+
+        public List<ResponseInterceptor> getResponseInterceptors() {
+            return responseInterceptors;
+        }
+
+        public void setResponseInterceptors(List<ResponseInterceptor> responseInterceptors) {
+            this.responseInterceptors = responseInterceptors;
+        }
     }
 }


### PR DESCRIPTION
see: https://github.com/micronaut-projects/micronaut-aws/issues/236

Given an application with two skills configured. 

```yml
alexa:
  skills:
    helloworld: 
      skill-id: 'xxx'   
    hellomoon: 
      skill-id: 'xxx'   
```
We may have a `LaunchRequest` handler for `helloworld`: 

```java
@Named("helloworld")
@Singleton
public class LaunchRequestHandler implements RequestHandler {

    @Override
    public boolean canHandle(HandlerInput input) {
        return input.matches(Predicates.requestType(LaunchRequest.class));
    }

    @Override
    public Optional<Response> handle(HandlerInput input) {
        String speechText = "Welcome to Hello World";
        return input.getResponseBuilder()
                .withSpeech(speechText)
                .build();
    }
}
```

And a different `LaunchRequest` handler for `hellomoon`: 

```java
@Named("hellomoon")
@Singleton
public class LaunchRequestHandler implements RequestHandler {

    @Override
    public boolean canHandle(HandlerInput input) {
        return input.matches(Predicates.requestType(LaunchRequest.class));
    }

    @Override
    public Optional<Response> handle(HandlerInput input) {
        String speechText = "Welcome to Hello Moon";
        return input.getResponseBuilder()
                .withSpeech(speechText)
                .build();
    }
}
```

However, we may want to share the same session handler to end the session: 

```java
@Singleton
public class SessionEndedRequestHandler implements RequestHandler {

    @Override
    public boolean canHandle(HandlerInput input) {
        return input.matches(requestType(SessionEndedRequest.class));
    }

    @Override
    public Optional<Response> handle(HandlerInput input) {
        // any cleanup logic goes here
        return input.getResponseBuilder().build();
    }
}
```

if a `RequestHandler` bean is not qualified with name, I consider it applies to every Alexa Skill. 
If a `RequestHandler` is qualfied with a name, it applies only to the Alexa Skill matching that name. 

We don't have a method in `ApplicationContext` such as `applicationContext.getBeansOfTypeNotQualifiedBy(RequestHandler.class, Qualifiers.byName(name)));` so this code is a bit more hairy.