### PR TITLE
Support for binary requests for the API Gateway

### DIFF
--- a/function-aws-api-proxy/build.gradle
+++ b/function-aws-api-proxy/build.gradle
@@ -22,5 +22,8 @@ dependencies {
     testImplementation "io.micronaut:micronaut-security:$micronautSecurity"
     testImplementation 'io.micronaut:micronaut-views'
     testImplementation "io.projectreactor:reactor-core"
+    testImplementation 'com.fasterxml.jackson.module:jackson-module-afterburner'
+    testImplementation 'javax.servlet:servlet-api:2.4'
+    testImplementation 'org.javadelight:delight-fileupload:0.0.5'
     testRuntimeOnly 'com.github.jknack:handlebars:4.1.2'
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyRequest.java
@@ -239,6 +239,9 @@ public class MicronautAwsProxyRequest<T> implements HttpRequest<T> {
             return Optional.of(decodedBody);
         }
         final String body = awsProxyRequest.getBody();
+        if (awsProxyRequest.isBase64Encoded()) {
+            return (Optional<T>) Optional.ofNullable(Base64.getMimeDecoder().decode(body));
+        }
         return (Optional<T>) Optional.ofNullable(body);
     }
 
@@ -250,6 +253,13 @@ public class MicronautAwsProxyRequest<T> implements HttpRequest<T> {
         }
         final String body = awsProxyRequest.getBody();
         if (body != null) {
+            if (awsProxyRequest.isBase64Encoded()) {
+                byte[] bytes = Base64.getMimeDecoder().decode(body);
+                if (type.getType().isInstance(bytes)) {
+                    return (Optional<T1>) Optional.of(bytes);
+                }
+                return ConversionService.SHARED.convert(bytes, type);
+            }
             if (type.getType().isInstance(body)) {
                 return (Optional<T1>) Optional.of(body);
             } else {


### PR DESCRIPTION
The current implementation only supports JSON inputs as all other content types must be sent in binary format. This PR adds the ability to handle binary requests.

The only problem with this PR is that it seems to me that there is a lack of converters from `byte[]` to other objects. Even automatic conversion from `byte[]` to `String` does not work. But this must be addressed in core libraries, not the AWS one.