### PR TITLE
GraalVM configuration files for AWS Lambda Custom Runtime

### DIFF
--- a/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/dynamic-proxy-config.json
+++ b/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/dynamic-proxy-config.json
@@ -1,0 +1,11 @@
+[
+  [
+    "org.apache.http.conn.HttpClientConnectionManager",
+    "org.apache.http.pool.ConnPoolControl",
+    "software.amazon.awssdk.http.apache.internal.conn.Wrapped"
+  ],
+  [
+    "org.apache.http.conn.ConnectionRequest",
+    "software.amazon.awssdk.http.apache.internal.conn.Wrapped"
+  ]
+]

--- a/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/native-image.properties
+++ b/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/native-image.properties
@@ -1,0 +1,7 @@
+Args = --report-unsupported-elements-at-runtime \
+       --initialize-at-run-time=io.netty.channel.epoll.Epoll,io.netty.channel.epoll.Native,io.netty.channel.epoll.EpollEventLoop,io.netty.channel.epoll.EpollEventArray,io.netty.channel.unix.Errors,io.netty.channel.unix.IovArray,io.netty.channel.unix.Socket,org.apache.commons.logging.LogFactory \
+       --initialize-at-build-time=org.apache.http.pool.ConnPoolControl,org.apache.http.HttpClientConnection,org.apache.http.conn.routing.HttpRoute,org.apache.http.conn.HttpClientConnectionManager,org.apache.http.protocol.HttpContext,org.apache.http.conn.ConnectionRequest,org.apache.http.client.config.RequestConfig,org.apache.http.client.config.RequestConfig$Builder \
+       -H:ReflectionConfigurationResources=${.}/reflection-config.json \
+       -H:DynamicProxyConfigurationResources=${.}/dynamic-proxy-config.json \
+       -H:+TraceClassInitialization \
+       -H:+ReportExceptionStackTraces

--- a/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/native-image.properties
+++ b/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/native-image.properties
@@ -1,7 +1,4 @@
-Args = --report-unsupported-elements-at-runtime \
-       --initialize-at-run-time=io.netty.channel.epoll.Epoll,io.netty.channel.epoll.Native,io.netty.channel.epoll.EpollEventLoop,io.netty.channel.epoll.EpollEventArray,io.netty.channel.unix.Errors,io.netty.channel.unix.IovArray,io.netty.channel.unix.Socket,org.apache.commons.logging.LogFactory \
+Args = --initialize-at-run-time=io.netty.channel.epoll.Epoll,io.netty.channel.epoll.Native,io.netty.channel.epoll.EpollEventLoop,io.netty.channel.epoll.EpollEventArray,io.netty.channel.unix.Errors,io.netty.channel.unix.IovArray,io.netty.channel.unix.Socket,org.apache.commons.logging.LogFactory \
        --initialize-at-build-time=org.apache.http.pool.ConnPoolControl,org.apache.http.HttpClientConnection,org.apache.http.conn.routing.HttpRoute,org.apache.http.conn.HttpClientConnectionManager,org.apache.http.protocol.HttpContext,org.apache.http.conn.ConnectionRequest,org.apache.http.client.config.RequestConfig,org.apache.http.client.config.RequestConfig$Builder \
        -H:ReflectionConfigurationResources=${.}/reflection-config.json \
-       -H:DynamicProxyConfigurationResources=${.}/dynamic-proxy-config.json \
-       -H:+TraceClassInitialization \
-       -H:+ReportExceptionStackTraces
+       -H:DynamicProxyConfigurationResources=${.}/dynamic-proxy-config.json

--- a/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/reflection-config.json
+++ b/function-aws-custom-runtime/src/main/resources/META-INF/native-image/io/micronaut/function/aws/runtime/reflection-config.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name":"org.apache.http.client.config.RequestConfig$Builder",
+    "allDeclaredMethods" : true
+  }
+]


### PR DESCRIPTION
This makes AWS SDK v2 with the Apache HTTP client to work inside a native image.

The Netty classes that I had to include I'm not sure if are coming from Micronaut (and hence we should move that config to core) or from AWS SDK's Netty client implementation.