### PR TITLE
[Issue/#410] Setting an unconfigured ProtocolConfiguration causes AWS SDK to use proxy

### DIFF
--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/netty/NettyClientConfiguration.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/netty/NettyClientConfiguration.java
@@ -42,7 +42,15 @@ public class NettyClientConfiguration extends AWSConfiguration {
      * @return The builder for {@link NettyNioAsyncHttpClient}
      */
     public NettyNioAsyncHttpClient.Builder getBuilder() {
-        return builder.proxyConfiguration(proxy.build());
+        ProxyConfiguration proxyConfig = proxy.build();
+        if (proxyConfig.scheme() == null &&
+                proxyConfig.host() == null &&
+                proxyConfig.nonProxyHosts().isEmpty()
+        ) {
+            return builder;
+        } else {
+            return builder.proxyConfiguration(proxyConfig);
+        }
     }
 
     /**

--- a/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/client/NettyClientSpec.groovy
+++ b/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/client/NettyClientSpec.groovy
@@ -24,4 +24,20 @@ class NettyClientSpec extends Specification {
         client.pools.proxyConfiguration.host == 'localhost'
     }
 
+    void "netty client should not be configured with empty proxy configuration"() {
+        given:
+        ApplicationContext applicationContext = ApplicationContext.run(
+                [
+                        'aws.netty-client.max-concurrency': 123
+                ]
+        )
+
+        when:
+        NettyNioAsyncHttpClient client = applicationContext.getBean(SdkAsyncHttpClient) as NettyNioAsyncHttpClient
+
+        then:
+        client.configuration().maxConnections() == 123
+        client.pools.proxyConfiguration == null
+    }
+
 }


### PR DESCRIPTION
Having a non null Protocol Configuration causes AWS SDK to use proxy

https://github.com/micronaut-projects/micronaut-aws/issues/410