### PR TITLE
refactor: Split proxy-test into beans

### DIFF
--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ContextProvider.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ContextProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.annotation.DefaultImplementation;
+
+/**
+ * Provides a Lambda execution environment's Context.
+ *
+ * @author Sergio del Amo
+ */
+@DefaultImplementation(MockContextProvider.class)
+@FunctionalInterface
+public interface ContextProvider {
+
+    /**
+     *
+     * @return A Context.
+     */
+    @NonNull
+    Context getContext();
+}

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/DefaultServletToAwsProxyRequestAdapter.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/DefaultServletToAwsProxyRequestAdapter.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+import com.amazonaws.serverless.proxy.model.ApiGatewayRequestIdentity;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequestContext;
+import com.amazonaws.serverless.proxy.model.Headers;
+import com.amazonaws.serverless.proxy.model.MultiValuedTreeMap;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.http.HttpMethod;
+import org.apache.commons.io.IOUtils;
+
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * {@link io.micronaut.context.annotation.DefaultImplementation} of {@link ServletToAwsProxyRequestAdapter}.
+ *
+ * @author Sergio del Amo
+ */
+@Singleton
+public class DefaultServletToAwsProxyRequestAdapter implements ServletToAwsProxyRequestAdapter {
+
+    @NonNull
+    @Override
+    public AwsProxyRequest createAwsProxyRequest(@NonNull HttpServletRequest request) {
+        AwsProxyRequest awsProxyRequest = new AwsProxyRequest();
+        awsProxyRequest.setRequestContext(createRequestContext(request));
+        awsProxyRequest.setHttpMethod(request.getMethod());
+        awsProxyRequest.setPath(request.getRequestURI());
+        awsProxyRequest.setMultiValueHeaders(createHeaders(request));
+        awsProxyRequest.setMultiValueQueryStringParameters(createParams(request));
+        boolean isBase64Encoded = encodeBodyAsBase64();
+        awsProxyRequest.setIsBase64Encoded(isBase64Encoded);
+        createBody(request, isBase64Encoded).ifPresent(awsProxyRequest::setBody);
+        return awsProxyRequest;
+    }
+
+    /**
+     *
+     * @param request A Servlet Request
+     * @return The request context
+     */
+    @NonNull
+    protected AwsProxyRequestContext createRequestContext(@NonNull HttpServletRequest request) {
+        AwsProxyRequestContext requestContext = new AwsProxyRequestContext();
+        requestContext.setIdentity(new ApiGatewayRequestIdentity());
+        requestContext.setHttpMethod(request.getMethod());
+        requestContext.setRequestTimeEpoch(Instant.now().toEpochMilli());
+        return requestContext;
+    }
+
+    /**
+     *
+     * @param request a Servlet request
+     * @return a {@link Headers} with the HTTP Headers of the request
+     */
+    @NonNull
+    protected Headers createHeaders(@NonNull HttpServletRequest request) {
+        Headers requestHeaders = new Headers();
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String s = headerNames.nextElement();
+            Enumeration<String> headers = request.getHeaders(s);
+            while (headers.hasMoreElements()) {
+                String v = headers.nextElement();
+                requestHeaders.add(s, v);
+            }
+        }
+        return requestHeaders;
+    }
+
+    /**
+     *
+     * @param request Servlet Request
+     * @return a {@link MultiValuedTreeMap} with the Request parameters
+     */
+    @NonNull
+    protected MultiValuedTreeMap<String, String> createParams(@NonNull HttpServletRequest request) {
+        Map<String, String[]> parameterMap = request.getParameterMap();
+        MultiValuedTreeMap<String, String> params = new MultiValuedTreeMap<>();
+        parameterMap.forEach((s, strings) -> params.addAll(s, s));
+        return params;
+    }
+
+    /**
+     *
+     * @return Whether to encode the body as Base64.
+     */
+    protected boolean encodeBodyAsBase64() {
+        return true;
+    }
+
+    /**
+     *
+     * @param request A Servlet request
+     * @param isBase64Encoded wether the request is base64 encoded or not
+     * @return An optional wrapping the request body as a base64 string or an empty optional
+     */
+    @NonNull
+    protected Optional<String> createBody(@NonNull HttpServletRequest request, boolean isBase64Encoded) {
+        HttpMethod httpMethod = HttpMethod.parse(request.getMethod());
+        if (HttpMethod.permitsRequestBody(httpMethod)) {
+            try (InputStream requestBody = request.getInputStream()) {
+                byte[] data = IOUtils.toByteArray(requestBody);
+                if (isBase64Encoded) {
+                    return Optional.of(Base64.getEncoder().encodeToString(data));
+                }
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/DefaultServletToAwsProxyResponseAdapter.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/DefaultServletToAwsProxyResponseAdapter.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.model.Headers;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.micronaut.http.HttpMethod;
+
+import javax.inject.Singleton;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * {@link io.micronaut.context.annotation.DefaultImplementation} of {@link ServletToAwsProxyResponseAdapter}.
+ *
+ * @author Sergio del Amo
+ */
+@Singleton
+public class DefaultServletToAwsProxyResponseAdapter implements ServletToAwsProxyResponseAdapter {
+    @Override
+    public void handle(@NonNull HttpServletRequest request,
+                       @NonNull AwsProxyResponse awsProxyResponse,
+                       @NonNull HttpServletResponse response) throws IOException {
+        Headers responseHeaders = awsProxyResponse.getMultiValueHeaders();
+
+        responseHeaders.forEach((key, strings) -> {
+            for (String string : strings) {
+                response.addHeader(key, string);
+            }
+        });
+        response.setStatus(awsProxyResponse.getStatusCode());
+        HttpMethod httpMethod = HttpMethod.parse(request.getMethod());
+        if (httpMethod != HttpMethod.HEAD && httpMethod != HttpMethod.OPTIONS) {
+
+            byte[] bodyAsBytes = parseBodyAsBytes(awsProxyResponse);
+            if (bodyAsBytes != null) {
+                response.setContentLength(bodyAsBytes.length);
+                if (bodyAsBytes.length > 0) {
+                    try (OutputStream responseBody = response.getOutputStream()) {
+                        responseBody.write(bodyAsBytes);
+                        responseBody.flush();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the response's body bytes considering whether the body was Base64 encoded.
+     * @param awsProxyResponse The response
+     * @return The response's body bytes.
+     */
+    @Nullable
+    protected byte[] parseBodyAsBytes(AwsProxyResponse awsProxyResponse) {
+        String body = awsProxyResponse.getBody();
+        return body == null ? null :
+                awsProxyResponse.isBase64Encoded() ? Base64.getDecoder().decode(body) : body.getBytes(getBodyCharset());
+    }
+
+    /**
+     *
+     * @return The charset used to read the response's body bytes.
+     */
+    protected Charset getBodyCharset() {
+        return StandardCharsets.UTF_8;
+    }
+}

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/MockContextProvider.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/MockContextProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.services.lambda.runtime.Context;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import javax.inject.Singleton;
+
+/**
+ * Provides a {@link MockLambdaContext}.
+ *
+ * @author Sergio del Amo
+ */
+@Singleton
+public class MockContextProvider implements ContextProvider {
+
+    /**
+     *
+     * @return a {@link MockLambdaContext}.
+     */
+    @NonNull
+    @Override
+    public Context getContext() {
+        return new MockLambdaContext();
+    }
+}

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ServerPort.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ServerPort.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+/**
+ * Encapsulates the port assignment to be used when starting a server.
+ *
+ * @author Sergio del Amo
+ */
+public class ServerPort {
+    private boolean random;
+    private Integer port;
+
+    /**
+     * Constructor.
+     */
+    public ServerPort() {
+    }
+
+    /**
+     *
+     * @param random Whether the port was randomly assigned
+     * @param port Port number
+     */
+    public ServerPort(boolean random, Integer port) {
+        this.random = random;
+        this.port = port;
+    }
+
+    /**
+     *
+     * @return Whether the port was randomly assigned
+     */
+    public boolean isRandom() {
+        return random;
+    }
+
+    /**
+     *
+     * @param random true if the port was randomly assigned
+     */
+    public void setRandom(boolean random) {
+        this.random = random;
+    }
+
+    /**
+     *
+     * @return The port number
+     */
+    public Integer getPort() {
+        return port;
+    }
+
+    /**
+     *
+     * @param port Port number
+     */
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+}

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ServletToAwsProxyRequestAdapter.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ServletToAwsProxyRequestAdapter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.annotation.DefaultImplementation;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Adapts from {@link HttpServletRequest} to {@link AwsProxyRequest}.
+ * @author Sergio del Amo
+ */
+@FunctionalInterface
+@DefaultImplementation(DefaultServletToAwsProxyRequestAdapter.class)
+public interface ServletToAwsProxyRequestAdapter {
+    /**
+     *
+     * @param request Servlets request
+     * @return An AWS Proxy request built from the servlet request supplied as a parameter
+     */
+    @NonNull
+    AwsProxyRequest createAwsProxyRequest(@NonNull HttpServletRequest request);
+
+}

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ServletToAwsProxyResponseAdapter.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/ServletToAwsProxyResponseAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.test;
+
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.micronaut.context.annotation.DefaultImplementation;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Writes the contents of a {@link AwsProxyResponse} to a {@link HttpServletResponse}.
+ * @author Sergio del Amo
+ */
+@DefaultImplementation(DefaultServletToAwsProxyResponseAdapter.class)
+@FunctionalInterface
+public interface ServletToAwsProxyResponseAdapter {
+
+    /**
+     *
+     * Writes the contents of a {@link AwsProxyResponse} to a {@link HttpServletResponse}.
+     *
+     * @param request Servlet Request
+     * @param awsProxyResponse The AWS proxy response
+     * @param response The Servlet Response
+     * @throws IOException can be thrown while writing the response
+     */
+    void handle(@NonNull HttpServletRequest request,
+                @NonNull AwsProxyResponse awsProxyResponse,
+                @NonNull HttpServletResponse response) throws IOException;
+}


### PR DESCRIPTION
@graemerocher I have split the proxy-test server into multiple beans. 

The goal is to make code a litter easier to process and also to provide users the ability to override certain beans in their test.  

toughts?