### PR TITLE
Initialize eagerly singletons and configuration

### DIFF
--- a/aws-alexa/build.gradle
+++ b/aws-alexa/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut:micronaut-http-server-netty"
+    testImplementation "org.codehaus.groovy:groovy-json:$groovyVersion"
     testRuntimeOnly "org.slf4j:jcl-over-slf4j:1.7.30"
 
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
@@ -127,7 +127,7 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
     /**
      * @return Any cookies
      */
-    Map<String, Cookie> getCookies() {
+    public Map<String, Cookie> getAllCookies() {
         return cookies;
     }
 

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -231,8 +231,10 @@ public final class MicronautLambdaContainerHandler
     public void initialize() throws ContainerInitializationException {
         Timer.start(TIMER_INIT);
         try {
-            this.applicationContext = applicationContextBuilder.environments(
-                    Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA)
+            this.applicationContext = applicationContextBuilder
+                    .environments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA)
+                    .eagerInitSingletons(true)
+                    .eagerInitConfiguration(true)
                     .build()
                     .start();
             this.lambdaContainerEnvironment.setApplicationContext(applicationContext);

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautResponseWriter.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautResponseWriter.java
@@ -68,7 +68,7 @@ public class MicronautResponseWriter extends ResponseWriter<MicronautAwsProxyRes
             Context lambdaContext) throws InvalidResponseObjectException {
         Timer.start(TIMER_NAME);
         AwsProxyResponse awsProxyResponse = containerResponse.getAwsResponse();
-        final Map<String, Cookie> cookies = containerResponse.getCookies();
+        final Map<String, Cookie> cookies = containerResponse.getAllCookies();
         if (CollectionUtils.isNotEmpty(cookies)) {
             final io.netty.handler.codec.http.cookie.Cookie[] nettyCookies = cookies.values().stream().filter(c -> c instanceof NettyCookie).map(c -> ((NettyCookie) c).getNettyCookie()).toArray(io.netty.handler.codec.http.cookie.Cookie[]::new);
             final List<String> values = ServerCookieEncoder.LAX.encode(nettyCookies);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 projectVersion=2.2.2.BUILD-SNAPSHOT
 micronautDocsVersion=1.0.24
-micronautVersion=2.0.0
+micronautVersion=2.1.2
 micronautBuildVersion=1.1.5
 micronautTestVersion=2.1.1
 groovyVersion=3.0.4


### PR DESCRIPTION
Add missing eager initialization of singletons and configuration in handler used as entry point for apps.

This fix needs https://github.com/micronaut-projects/micronaut-core/issues/4316 which will be included in Micronaut 2.1.2.

In my test application the cold start went from 12 seconds to 9 with this change.