### PR TITLE
Make method package protected again

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
@@ -127,7 +127,7 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
     /**
      * @return Any cookies
      */
-    public Map<String, Cookie> getAllCookies() {
+    Map<String, Cookie> getAllCookies() {
         return cookies;
     }
 


### PR DESCRIPTION
In #613 I accidentally left `getAllCookies` method public. Reverting it back to package private.