### PR TITLE
Configurable AWS Parameter Store queries

### DIFF
--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/AWSParameterQueryProvider.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/AWSParameterQueryProvider.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.discovery.aws.parameterstore;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import io.micronaut.context.annotation.DefaultImplementation;
 import io.micronaut.context.env.Environment;
 
@@ -37,9 +38,19 @@ import java.util.Optional;
  * }}
  * </pre>
  *
+ * @author ttzn
  * @since 2.1.2
  */
 @DefaultImplementation(DefaultParameterQueryProvider.class)
 public interface AWSParameterQueryProvider {
-    List<ParameterQuery> getParameterQueries(Environment environment, Optional<String> serviceId, AWSParameterStoreConfiguration configuration);
+    /**
+     * @param environment the current application environment
+     * @param serviceId the service ID or application name, if applicable
+     * @param configuration the parameter store configuration
+     * @return a list of {@link ParameterQuery} that will be used to configure calls
+     * to the Parameter Store
+     */
+    @NonNull List<ParameterQuery> getParameterQueries(@NonNull Environment environment,
+                                                      @NonNull Optional<String> serviceId,
+                                                      @NonNull AWSParameterStoreConfiguration configuration);
 }

--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/AWSParameterQueryProvider.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/AWSParameterQueryProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.aws.parameterstore;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.context.env.Environment;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Definition of a service that provides a list of {@link ParameterQuery} objects
+ * to be processed by the configuration client. Users who wish to search their
+ * own custom paths need to implement this interface and replace the default
+ * implementation:
+ *
+ * <pre>
+ * {@code
+ * @Replaces(AWSParameterQueryProvider.class)
+ * public class CustomParameterQueryProvider implements AWSParameterQueryProvider {
+ *
+ * ...
+ *
+ * }}
+ * </pre>
+ *
+ * @since 2.1.2
+ */
+@DefaultImplementation(DefaultParameterQueryProvider.class)
+public interface AWSParameterQueryProvider {
+    List<ParameterQuery> getParameterQueries(Environment environment, Optional<String> serviceId, AWSParameterStoreConfiguration configuration);
+}

--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/DefaultParameterQueryProvider.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/DefaultParameterQueryProvider.java
@@ -17,6 +17,7 @@ package io.micronaut.discovery.aws.parameterstore;
 
 import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.EnvironmentPropertySource;
+import io.micronaut.core.annotation.Internal;
 
 import javax.inject.Singleton;
 import java.util.ArrayList;
@@ -24,8 +25,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ *
+ *
+ * @author ttzn
+ * @since 2.1.2
+ */
+@Internal
 @Singleton
-class DefaultParameterQueryProvider implements AWSParameterQueryProvider {
+final class DefaultParameterQueryProvider implements AWSParameterQueryProvider {
     private static int basePriority = EnvironmentPropertySource.POSITION + 100;
     private static int envBasePriority = basePriority + 50;
 

--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/DefaultParameterQueryProvider.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/DefaultParameterQueryProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.aws.parameterstore;
+
+import io.micronaut.context.env.Environment;
+import io.micronaut.context.env.EnvironmentPropertySource;
+
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Singleton
+class DefaultParameterQueryProvider implements AWSParameterQueryProvider {
+    private static int basePriority = EnvironmentPropertySource.POSITION + 100;
+    private static int envBasePriority = basePriority + 50;
+
+    @Override
+    public List<ParameterQuery> getParameterQueries(Environment environment, Optional<String> serviceId, AWSParameterStoreConfiguration configuration) {
+        List<String> activeNames = configuration.isSearchActiveEnvironments() ?
+                new ArrayList<>(environment.getActiveNames()) : Collections.emptyList();
+        String path = configuration.getRootHierarchyPath();
+        String normalizedPath = !path.endsWith("/") ? path + "/" : path;
+        String commonConfigPath = normalizedPath + Environment.DEFAULT_NAME;
+        final boolean hasApplicationSpecificConfig = serviceId.isPresent();
+        String applicationSpecificPath = hasApplicationSpecificConfig ? normalizedPath + serviceId.get() : null;
+
+        List<ParameterQuery> queries = new ArrayList<>();
+        addNameAndPathQueries(queries, commonConfigPath, Environment.DEFAULT_NAME, basePriority + 1);
+        if (hasApplicationSpecificConfig) {
+            addNameAndPathQueries(queries, applicationSpecificPath, serviceId.get(), basePriority + 2);
+        }
+
+        for (int i = 0; i < activeNames.size(); i++) {
+            String activeName = activeNames.get(i);
+            String environmentSpecificPath = commonConfigPath + "_" + activeName;
+            String propertySourceName = Environment.DEFAULT_NAME + "[" + activeName + "]";
+            int priority = envBasePriority + i * 2;
+
+            addNameAndPathQueries(queries, environmentSpecificPath, propertySourceName, priority);
+            if (hasApplicationSpecificConfig) {
+                String appEnvironmentSpecificPath = applicationSpecificPath + "_" + activeName;
+                propertySourceName = serviceId.get() + "[" + activeName + "]";
+                addNameAndPathQueries(queries, appEnvironmentSpecificPath, propertySourceName, priority + 1);
+            }
+        }
+
+        return queries;
+    }
+
+    private void addNameAndPathQueries(List<ParameterQuery> queries, String value, String propertySourceName, int priority) {
+        queries.add(new ParameterQuery(value, propertySourceName, priority, true));
+        queries.add(new ParameterQuery(value, propertySourceName, priority, false));
+    }
+}

--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/ParameterQuery.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/ParameterQuery.java
@@ -20,6 +20,7 @@ package io.micronaut.discovery.aws.parameterstore;
  * configuration values to the Parameter Store, as well as the name of the
  * resulting property source and associated priority.
  *
+ * @author ttzn
  * @since 2.1.2
  */
 public class ParameterQuery {

--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/ParameterQuery.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/ParameterQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.discovery.aws.parameterstore;
+
+/**
+ * An object encapsulating all necessary parameters to perform a request for
+ * configuration values to the Parameter Store, as well as the name of the
+ * resulting property source and associated priority.
+ *
+ * @since 2.1.2
+ */
+public class ParameterQuery {
+    private final String path;
+    private final String propertySourceName;
+    private final int priority;
+    private final boolean name;
+
+    public ParameterQuery(String path, String propertySourceName, int priority) {
+        this(path, propertySourceName, priority, false);
+    }
+
+    public ParameterQuery(String path, String propertySourceName, int priority, boolean name) {
+        this.path = path;
+        this.propertySourceName = propertySourceName;
+        this.name = name;
+        this.priority = priority;
+    }
+
+    /**
+     * @return the path to be used when querying the Parameter Store; if {@link #isName()} is true,
+     * it will be used as <code>names</code> in a GetParameters request,
+     * call, otherwise it is the <code>path</code> parameter of a GetParametersByPath.
+     */
+    public String getPath() {
+        return path;
+    }
+
+    /**
+     * @return the name of the property source that will hold the retrieved configuration values.
+     */
+    public String getPropertySourceName() {
+        return propertySourceName;
+    }
+
+    /**
+     * @return whether the current query should be performed using the GetParameters API instead of
+     * GetParametersByPath. This is almost never not what you want.
+     */
+    public boolean isName() {
+        return name;
+    }
+
+    /**
+     * @return the priority of the property source that will hold the retrieved configuration values.
+     */
+    public int getPriority() {
+        return priority;
+    }
+}

--- a/aws-parameter-store/src/test/groovy/io/micronaut/discovery/aws/parameterstore/AWSPropertyStoreMockConfigurationClientSpec.groovy
+++ b/aws-parameter-store/src/test/groovy/io/micronaut/discovery/aws/parameterstore/AWSPropertyStoreMockConfigurationClientSpec.groovy
@@ -16,11 +16,7 @@
 package io.micronaut.discovery.aws.parameterstore
 
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementAsync
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathResult
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersRequest
-import com.amazonaws.services.simplesystemsmanagement.model.GetParametersResult
-import com.amazonaws.services.simplesystemsmanagement.model.Parameter
+import com.amazonaws.services.simplesystemsmanagement.model.*
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.Environment
 import io.micronaut.context.env.EnvironmentPropertySource
@@ -32,6 +28,7 @@ import io.reactivex.Flowable
 import spock.lang.AutoCleanup
 import spock.lang.Shared
 import spock.lang.Specification
+
 import java.util.concurrent.FutureTask
 
 /**
@@ -421,5 +418,58 @@ class AWSPropertyStoreMockConfigurationClientSpec extends Specification {
             assert it.contains('/config/application')
             assert it.contains('/config/amazon-test')
         }
+    }
+
+    void "custom parameter query providers can be configured"() {
+        given:
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer,
+                [
+                        'aws.client.system-manager.parameterstore.enabled'                  : 'true',
+                        'micronaut.application.name'                                        : 'amazonTest'],
+                Environment.AMAZON_EC2
+
+        )
+        AWSParameterStoreConfigClient client = embeddedServer.applicationContext.getBean(AWSParameterStoreConfigClient)
+
+        client.client = Mock(AWSSimpleSystemsManagementAsync)
+        client.queryProvider = (env, serviceId, configuration) -> [
+            new ParameterQuery("/root/application", "/root/application", -1),
+            new ParameterQuery('/config/foo', '/config/foo', -10)
+        ]
+
+        def searchedPaths = []
+        client.client.getParametersByPathAsync(_) >> { GetParametersByPathRequest getRequest ->
+
+            searchedPaths += getRequest.path
+
+            def result = new GetParametersByPathResult()
+            if (getRequest.path.startsWith("/root/application")) {
+                def parameter = new Parameter(
+                        name: "/root/application/someKey",
+                        value: "someValue",
+                        type: "String")
+                result.setParameters([parameter])
+            }
+
+            FutureTask<GetParametersByPathResult> futureTask = Mock(FutureTask)
+            futureTask.isDone() >> { return true }
+            futureTask.get() >> {
+                return result
+            }
+            return futureTask
+        }
+
+        when:
+        def env = Mock(Environment)
+        env.getActiveNames() >> (['first', 'second'] as Set)
+        def propertySources = Flowable.fromPublisher(client.getPropertySources(env)).toList().blockingGet()
+
+        then: "verify that the custom paths were searched"
+        propertySources.size() == 1
+        propertySources[0].get('someKey') == 'someValue'
+
+        assert searchedPaths.size() == 2
+        assert searchedPaths.contains('/root/application')
+        assert searchedPaths.contains('/config/foo')
     }
 }

--- a/aws-parameter-store/src/test/groovy/io/micronaut/discovery/aws/parameterstore/AWSPropertyStoreMockConfigurationClientSpec.groovy
+++ b/aws-parameter-store/src/test/groovy/io/micronaut/discovery/aws/parameterstore/AWSPropertyStoreMockConfigurationClientSpec.groovy
@@ -461,15 +461,14 @@ class AWSPropertyStoreMockConfigurationClientSpec extends Specification {
 
         when:
         def env = Mock(Environment)
-        env.getActiveNames() >> (['first', 'second'] as Set)
         def propertySources = Flowable.fromPublisher(client.getPropertySources(env)).toList().blockingGet()
 
         then: "verify that the custom paths were searched"
         propertySources.size() == 1
         propertySources[0].get('someKey') == 'someValue'
 
-        assert searchedPaths.size() == 2
-        assert searchedPaths.contains('/root/application')
-        assert searchedPaths.contains('/config/foo')
+        searchedPaths.size() == 2
+        searchedPaths.contains('/root/application')
+        searchedPaths.contains('/config/foo')
     }
 }


### PR DESCRIPTION
This PR resolves #657 by adding the ability to declare an `AWSParameterQueryResolver` in cases where the default `/config/application` and `/config/project_name` base paths are undesirable. A package-protected default implementation is provided that preserves the current behaviour.

I also took the liberty to rewrite the very long `getPropertySources()` method in a more pipeline-like fashion, with transformations encapsulated in their own methods.

There is some complexity that is due to the fact that the current implementation uses both `GetParameters` and `GetParametersByPath` AWS API calls to retrieve configuration values. Unless I missed some legacy quirk, a call such as `aws ssm get-parameters --name "/config/application"` doesn't seem to make sense, as it will only return something if a parameter named `/config/application` exists, but that would result in a property with an empty string key. I am not sure that is intended (maybe a separate issue should be opened), nevertheless I added the possibility to do both styles of queries with a `name` flag, so that all current tests pass and backwards compatibility is preserved.