### PR TITLE
Inject preconstructed ApplicationContext in Lambda handler

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaHandler.java
@@ -48,10 +48,19 @@ public class MicronautLambdaHandler implements RequestHandler<AwsProxyRequest, A
     /**
      * Constructor.
      * @param applicationContextBuilder Application Context Builder
-     * @throws ContainerInitializationException thrown intializing {@link MicronautLambdaHandler}
+     * @throws ContainerInitializationException thrown initializing {@link MicronautLambdaHandler}
      */
     public MicronautLambdaHandler(ApplicationContextBuilder applicationContextBuilder) throws ContainerInitializationException {
         this.handler = new MicronautLambdaContainerHandler(applicationContextBuilder);
+    }
+
+    /**
+     * Constructor.
+     * @param applicationContext Application Context (must be started already)
+     * @throws ContainerInitializationException thrown initializing {@link MicronautLambdaHandler}
+     */
+    public MicronautLambdaHandler(ApplicationContext applicationContext) throws ContainerInitializationException {
+        this.handler = new MicronautLambdaContainerHandler(applicationContext);
     }
 
     @Override

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MicronautLambdaHandlerSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MicronautLambdaHandlerSpec.groovy
@@ -1,0 +1,64 @@
+package io.micronaut.function.aws.proxy
+
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.function.aws.LambdaApplicationContextBuilder
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
+import spock.lang.Specification
+
+class MicronautLambdaHandlerSpec extends Specification {
+    /*
+    Simple test to ensure that constructing with a builder or a fully-initialized ApplicationContext
+    has no effect on the behaviour.
+     */
+    void "injected ApplicationContext preserves behaviour"() {
+        given:
+        MicronautLambdaHandler handler = new MicronautLambdaHandler(ApplicationContext.build().properties([
+                'spec.name': 'MicronautLambdaHandlerSpec'
+        ]))
+        ApplicationContext context = new LambdaApplicationContextBuilder()
+                .properties([
+                        'spec.name': 'MicronautLambdaHandlerSpec'
+                ])
+                .build()
+                .start()
+        MicronautLambdaHandler injectedHandler = new MicronautLambdaHandler(context)
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/foo', HttpMethod.GET.toString())
+        builder.queryString("param", "value")
+
+        when:
+        def response = handler.handleRequest(builder.build(), new MockLambdaContext())
+        def injectedResponse = injectedHandler.handleRequest(builder.build(), new MockLambdaContext())
+
+        then:
+        injectedResponse.statusCode == response.statusCode
+        injectedResponse.body == response.body
+        injectedResponse.headers == response.headers
+
+        cleanup:
+        if (handler != null)
+            handler.close()
+        if (injectedHandler != null)
+            injectedHandler.close()
+    }
+
+    @Secured(SecurityRule.IS_ANONYMOUS)
+    @Controller
+    @Requires(property = 'spec.name', value = 'MicronautLambdaHandlerSpec')
+    static class SimpleController {
+        @Get(uri = "/foo")
+        HttpResponse<String> getParamValue(HttpRequest request) {
+            return HttpResponse.ok()
+                    .body(request.getParameters().get("param"))
+                    .header("foo", "bar")
+        }
+    }
+}

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/MicronautAwsProxyTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/MicronautAwsProxyTest.java
@@ -29,6 +29,8 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MediaType;
 import org.apache.commons.codec.binary.Base64;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,26 +60,8 @@ public class MicronautAwsProxyTest {
     private static final String AUTHORIZER_PRINCIPAL_ID = "test-principal-" + UUID.randomUUID().toString();
     private static final String USER_PRINCIPAL = "user1";
 
-
     private static ObjectMapper objectMapper = new ObjectMapper();
     private static MicronautLambdaContainerHandler handler;
-
-    static {
-        try {
-            handler = new MicronautLambdaContainerHandler(
-                        ApplicationContext.build(CollectionUtils.mapOf(
-                                "spec.name", "MicronautAwsProxyTest",
-                                "micronaut.security.enabled", true,
-                                "micronaut.views.handlebars.enabled", true,
-                                "micronaut.router.static-resources.lorem.paths", "classpath:static-lorem/",
-                                "micronaut.router.static-resources.lorem.mapping", "/static-lorem/**"
-                        ))
-                );
-        } catch (ContainerInitializationException e) {
-            throw new RuntimeException("Test failed to start: " + e.getMessage(), e);
-        }
-    }
-
     private static Context lambdaContext = new MockLambdaContext();
 
     private boolean isAlb;
@@ -86,7 +70,29 @@ public class MicronautAwsProxyTest {
         isAlb = alb;
     }
 
-    @Parameterized.Parameters
+    @BeforeClass
+    public static void initHandler() {
+        try {
+            handler = new MicronautLambdaContainerHandler(
+                    ApplicationContext.build(CollectionUtils.mapOf(
+                            "spec.name", "MicronautAwsProxyTest",
+                            "micronaut.security.enabled", true,
+                            "micronaut.views.handlebars.enabled", true,
+                            "micronaut.router.static-resources.lorem.paths", "classpath:static-lorem/",
+                            "micronaut.router.static-resources.lorem.mapping", "/static-lorem/**"
+                    ))
+            );
+        } catch (ContainerInitializationException e) {
+            throw new RuntimeException("Test failed to start: " + e.getMessage(), e);
+        }
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        handler.close();
+    }
+
+    @Parameterized.Parameters(name = "isALB == {0}")
     public static Collection<Object> data() {
         return Arrays.asList(new Object[] { false, true });
     }

--- a/function-aws-test/build.gradle
+++ b/function-aws-test/build.gradle
@@ -1,0 +1,9 @@
+dependencies {
+    compileOnly "io.micronaut:micronaut-inject-java"
+    annotationProcessor "io.micronaut:micronaut-inject-java"
+    implementation "io.micronaut.test:micronaut-test-junit5:$micronautTestVersion"
+    api project(":function-aws")
+    api "io.micronaut:micronaut-function:$micronautVersion"
+
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+}

--- a/function-aws-test/src/main/java/io/micronaut/function/aws/test/MicronautLambdaJunit5Extension.java
+++ b/function-aws-test/src/main/java/io/micronaut/function/aws/test/MicronautLambdaJunit5Extension.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.test;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.function.aws.LambdaApplicationContextBuilder;
+import io.micronaut.function.aws.test.annotation.MicronautLambdaTest;
+import io.micronaut.test.annotation.MicronautTestValue;
+import io.micronaut.test.context.TestContext;
+import io.micronaut.test.extensions.junit5.MicronautJunit5Extension;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstantiationException;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.util.Optional;
+
+/**
+ * Extension for testing Lambda environments with Junit 5.
+ *
+ * @author graemerocher
+ * @since 1.0
+ */
+public class MicronautLambdaJunit5Extension extends MicronautJunit5Extension {
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(MicronautLambdaJunit5Extension.class);
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        final Class<?> testClass = extensionContext.getRequiredTestClass();
+        MicronautTestValue micronautTestValue = AnnotationSupport
+                        .findAnnotation(testClass, MicronautLambdaTest.class)
+                        .map(this::buildValueObject)
+                        .orElse(null);
+        beforeClass(extensionContext, testClass, micronautTestValue);
+        getStore(extensionContext).put(ApplicationContext.class, applicationContext);
+        if (specDefinition != null) {
+            TestInstance ti = AnnotationSupport.findAnnotation(testClass, TestInstance.class).orElse(null);
+            if (ti != null && ti.value() == TestInstance.Lifecycle.PER_CLASS) {
+                Object testInstance = extensionContext.getRequiredTestInstance();
+                applicationContext.inject(testInstance);
+            }
+        }
+        beforeTestClass(buildContext(extensionContext));
+    }
+
+    private static ExtensionContext.Store getStore(ExtensionContext context) {
+        return context.getRoot().getStore(NAMESPACE);
+    }
+
+    private TestContext buildContext(ExtensionContext context) {
+        return new TestContext(
+                applicationContext,
+                context.getTestClass().orElse(null),
+                context.getTestMethod().orElse(null),
+                context.getTestInstance().orElse(null),
+                context.getExecutionException().orElse(null));
+    }
+
+    @SuppressWarnings("unchecked")
+    private MicronautTestValue buildValueObject(MicronautLambdaTest micronautTest) {
+        return new MicronautTestValue(
+                micronautTest.application(),
+                micronautTest.environments(),
+                micronautTest.packages(),
+                micronautTest.propertySources(),
+                micronautTest.rollback(),
+                micronautTest.transactional(),
+                micronautTest.rebuildContext(),
+                new Class[]{ LambdaApplicationContextBuilder.class },
+                micronautTest.transactionMode(),
+                micronautTest.startApplication());
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+        final Optional<Object> testInstance = extensionContext.getTestInstance();
+        if (testInstance.isPresent()) {
+
+            final Class<?> requiredTestClass = extensionContext.getRequiredTestClass();
+            if (applicationContext.containsBean(requiredTestClass)) {
+                return ConditionEvaluationResult.enabled("Test bean active");
+            } else {
+
+                final boolean hasBeanDefinition = isTestSuiteBeanPresent(requiredTestClass);
+                if (!hasBeanDefinition) {
+                    throw new TestInstantiationException(MISCONFIGURED_MESSAGE);
+                } else {
+                    return ConditionEvaluationResult.disabled(DISABLED_MESSAGE);
+                }
+
+            }
+        } else {
+            final Class<?> testClass = extensionContext.getRequiredTestClass();
+            if (AnnotationSupport.isAnnotated(testClass, MicronautLambdaTest.class)) {
+                return ConditionEvaluationResult.enabled("Test bean active");
+            } else {
+                return ConditionEvaluationResult.disabled(DISABLED_MESSAGE);
+            }
+        }
+    }
+}

--- a/function-aws-test/src/main/java/io/micronaut/function/aws/test/annotation/MicronautLambdaTest.java
+++ b/function-aws-test/src/main/java/io/micronaut/function/aws/test/annotation/MicronautLambdaTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.test.annotation;
+
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.function.aws.test.MicronautLambdaJunit5Extension;
+import io.micronaut.test.annotation.TransactionMode;
+import io.micronaut.test.condition.TestActiveCondition;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation that can be applied to any JUnit 5 test to enable testing
+ * AWS Lambda handlers with a pre-configured ApplicationContext. Based on
+ * {@link io.micronaut.test.extensions.junit5.annotation.MicronautTest}
+ * and supports the same options.
+ *
+ * @author ttz
+ * @since 2.3.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@ExtendWith(MicronautLambdaJunit5Extension.class)
+@Factory
+@Inherited
+@Requires(condition = TestActiveCondition.class)
+public @interface MicronautLambdaTest {
+    /**
+     * @return The application class of the application
+     */
+    Class<?> application() default void.class;
+
+    /**
+     * @return The environments to use.
+     */
+    String[] environments() default {};
+
+    /**
+     * @return The packages to consider for scanning.
+     */
+    String[] packages() default {};
+
+    /**
+     * One or many references to classpath. For example: "classpath:mytest.yml"
+     *
+     * @return The property sources
+     */
+    String[] propertySources() default {};
+
+    /**
+     * Whether to rollback (if possible) any data access code between each test execution.
+     *
+     * @return True if changes should be rolled back
+     */
+    boolean rollback() default true;
+
+    /**
+     * Allow disabling or enabling of automatic transaction wrapping.
+     * @return Whether to wrap a test in a transaction.
+     */
+    boolean transactional() default true;
+
+    /**
+     * Whether to rebuild the application context before each test method.
+     * @return true if the application context should be rebuilt for each test method
+     */
+    boolean rebuildContext() default false;
+
+    /**
+     * The transaction mode describing how transactions should be handled for each test.
+     * @return The transaction mode
+     */
+    TransactionMode transactionMode() default TransactionMode.SEPARATE_TRANSACTIONS;
+
+    /**
+     * <p>Whether to start {@link io.micronaut.runtime.EmbeddedApplication}.</p>
+     *
+     * <p>When false, only the application context will be started.
+     * This can be used to disable {@link io.micronaut.runtime.server.EmbeddedServer}.</p>
+     *
+     * @return true if {@link io.micronaut.runtime.EmbeddedApplication} should be started
+     */
+    boolean startApplication() default true;
+}

--- a/function-aws-test/src/main/java/io/micronaut/function/aws/test/annotation/MicronautLambdaTest.java
+++ b/function-aws-test/src/main/java/io/micronaut/function/aws/test/annotation/MicronautLambdaTest.java
@@ -28,9 +28,9 @@ import java.lang.annotation.*;
  * Annotation that can be applied to any JUnit 5 test to enable testing
  * AWS Lambda handlers with a pre-configured ApplicationContext. Based on
  * {@link io.micronaut.test.extensions.junit5.annotation.MicronautTest}
- * and supports the same options.
+ * and supports the same options except contextBuilder.
  *
- * @author ttz
+ * @author ttzn
  * @since 2.3.0
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/function-aws-test/src/test/java/io/micronaut/function/aws/test/EagerSingleton.java
+++ b/function-aws-test/src/test/java/io/micronaut/function/aws/test/EagerSingleton.java
@@ -1,0 +1,7 @@
+package io.micronaut.function.aws.test;
+
+import javax.inject.Singleton;
+
+@Singleton
+public class EagerSingleton {
+}

--- a/function-aws-test/src/test/java/io/micronaut/function/aws/test/MicronautLambdaExtensionTest.java
+++ b/function-aws-test/src/test/java/io/micronaut/function/aws/test/MicronautLambdaExtensionTest.java
@@ -1,0 +1,26 @@
+package io.micronaut.function.aws.test;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.BeanRegistration;
+import io.micronaut.function.aws.test.annotation.MicronautLambdaTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.*;
+
+@MicronautLambdaTest
+public class MicronautLambdaExtensionTest {
+    @Inject
+    ApplicationContext context;
+
+    @Test
+    public void testContextProperlyConfigured() {
+        Set<String> expectedNames = new HashSet<>(Arrays.asList("test", "function", "lambda"));
+        Assertions.assertNotNull(context);
+        Assertions.assertEquals(context.getEnvironment().getActiveNames(), expectedNames);
+        Collection<BeanRegistration<EagerSingleton>> registrations =
+                context.getActiveBeanRegistrations(EagerSingleton.class);
+        Assertions.assertEquals(1, registrations.size());
+    }
+}

--- a/function-aws-test/src/test/resources/logback.xml
+++ b/function-aws-test/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.function.aws" level="TRACE"/>
+</configuration>

--- a/function-aws/src/main/java/io/micronaut/function/aws/LambdaApplicationContextBuilder.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/LambdaApplicationContextBuilder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.function.aws;
 
+import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.DefaultApplicationContextBuilder;
 import io.micronaut.context.env.Environment;
 
@@ -26,8 +27,13 @@ import io.micronaut.context.env.Environment;
  */
 public class LambdaApplicationContextBuilder extends DefaultApplicationContextBuilder {
     public LambdaApplicationContextBuilder() {
-        environments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA);
-        eagerInitConfiguration(true);
-        eagerInitSingletons(true);
+        setLambdaConfiguration(this);
+    }
+
+    public static void setLambdaConfiguration(ApplicationContextBuilder builder) {
+        builder
+            .environments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA)
+            .eagerInitConfiguration(true)
+            .eagerInitSingletons(true);
     }
 }

--- a/function-aws/src/main/java/io/micronaut/function/aws/LambdaApplicationContextBuilder.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/LambdaApplicationContextBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import io.micronaut.context.DefaultApplicationContextBuilder;
+import io.micronaut.context.env.Environment;
+
+/**
+ * An {@link io.micronaut.context.ApplicationContextBuilder} for AWS Lambda environments.
+ *
+ * @author ttzn
+ * @since 2.3.0
+ */
+public class LambdaApplicationContextBuilder extends DefaultApplicationContextBuilder {
+    public LambdaApplicationContextBuilder() {
+        environments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA);
+        eagerInitConfiguration(true);
+        eagerInitSingletons(true);
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -53,10 +53,24 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     private final Class<I> inputType = initTypeArgument();
 
     /**
-     * Constructor.
+     * Default constructor; will initialize a suitable {@link ApplicationContext} for
+     * Lambda deployment.
      */
     public MicronautRequestHandler() {
         buildApplicationContext(null);
+        injectIntoApplicationContext();
+    }
+
+    /**
+     * Constructor used to inject a preexisting {@link ApplicationContext}.
+     * @param applicationContext the application context
+     */
+    public MicronautRequestHandler(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        injectIntoApplicationContext();
+    }
+
+    private void injectIntoApplicationContext() {
         applicationContext.inject(this);
     }
 
@@ -154,10 +168,7 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     @Nonnull
     @Override
     protected ApplicationContextBuilder newApplicationContextBuilder() {
-        return super.newApplicationContextBuilder()
-                .environments(ENVIRONMENT_LAMBDA)
-                .eagerInitSingletons(true)
-                .eagerInitConfiguration(true);
+        return new LambdaApplicationContextBuilder();
     }
 
     /**

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -40,13 +40,22 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
     private String functionName;
 
     /**
-     * Default constructor.
+     * Default constructor; will initialize a suitable {@link ApplicationContext} for
+     * Lambda deployment.
      */
     public MicronautRequestStreamHandler() {
         // initialize the application context in the constructor
         // this is faster in Lambda as init cost is giving higher processor priority
         // see https://github.com/micronaut-projects/micronaut-aws/issues/18#issuecomment-530903419
         buildApplicationContext(null);
+    }
+
+    /**
+     * Constructor used to inject a preexisting {@link ApplicationContext}.
+     * @param applicationContext the application context
+     */
+    public MicronautRequestStreamHandler(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
     }
 
     @Override
@@ -67,10 +76,7 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
     @Nonnull
     @Override
     protected ApplicationContextBuilder newApplicationContextBuilder() {
-        return super.newApplicationContextBuilder()
-                .environments(ENVIRONMENT_LAMBDA)
-                .eagerInitSingletons(true)
-                .eagerInitConfiguration(true);
+        return new LambdaApplicationContextBuilder();
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,7 @@ micronautBuildVersion=1.1.5
 micronautTestVersion=2.2.1
 groovyVersion=3.0.4
 spockVersion=2.0-M3-groovy-3.0
+junitVersion=5.7.0
 
 micronautSecurity=2.2.0
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,4 @@ include 'function-aws-custom-runtime'
 include 'aws-common'
 include 'aws-sdk-v1'
 include 'aws-sdk-v2'
-
+include 'function-aws-test'

--- a/src/main/docs/guide/lambda/lambdaTesting.adoc
+++ b/src/main/docs/guide/lambda/lambdaTesting.adoc
@@ -1,0 +1,51 @@
+To test Lambda handlers with JUnit 5, use the api:io.micronaut.function.aws.test.MicronautLambdaTest[]
+annotation which will configure a suitable `ApplicationContext` for use in a Lambda environment. The following
+dependency is needed:
+
+dependency:micronaut-function-aws-test[scope="testImplementation"]
+
+Testing subclasses of `MicronautRequestHandler` or `MicronautRequestStreamHandler` with this annotation requires
+both a no-arg and a one-arg constructor, the latter being used to inject the test application context:
+
+```java
+public class SampleRequestHandler extends MicronautRequestHandler<String, String> {
+    // Used in AWS
+    public SampleRequestHandler() {
+    }
+
+    // Used in tests
+    public SampleRequestHandler(ApplicationContext applicationContext) {
+        super(applicationContext);
+    }
+
+    @Override
+    public String execute(String input) {
+        return null;
+    }
+}
+```
+
+Example usage:
+
+```java
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.function.aws.test.annotation.MicronautLambdaTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+@MicronautLambdaTest
+public class RequestHandlerTest {
+    @Inject
+    private ApplicationContext context;
+
+    @Test
+    void testHandler() {
+        SampleRequestHandler sampleRequestHandler = new SampleRequestHandler(context);
+        // ...
+    }
+}
+```
+
+The annotation supports the same options as `@MicronautTest`, except that you may not specify a custom
+`ApplicationContextBuilder` class.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -26,6 +26,7 @@ lambda:
   customRuntimes: GraalVM and AWS Custom runtimes
   mdc: MDC Logging
   lambdaTutorials: Micronaut AWS Lambda Tutorials
+  lambdaTesting: Testing Lambda Handlers
 alexa:
   title: Alexa Support
   ssmlbuilder: SSML Builder


### PR DESCRIPTION
This helps solving https://github.com/micronaut-projects/micronaut-test/issues/330. It basically allows initializing `MicronautRequestHandler`s with the app context from a `@MicronautTest` in this fashion:

```kotlin
@MicronautTest(contextBuilder = [LambdaApplicationContextBuilder::class])
class RequestHandlerTest {
    @Inject
    lateinit var context: ApplicationContext

    @Test
    fun testHandler() {
        val sampleRequestHandler = SampleRequestHandler(context)
        ...
```

This is probably still too much work on the user's part. Before going further I'd like this to be validated first.