### PR TITLE
Fix request parameter gathering in AWS proxy adapter

### DIFF
--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/DefaultServletToAwsProxyRequestAdapter.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/DefaultServletToAwsProxyRequestAdapter.java
@@ -100,7 +100,7 @@ public class DefaultServletToAwsProxyRequestAdapter implements ServletToAwsProxy
     protected MultiValuedTreeMap<String, String> createParams(@NonNull HttpServletRequest request) {
         Map<String, String[]> parameterMap = request.getParameterMap();
         MultiValuedTreeMap<String, String> params = new MultiValuedTreeMap<>();
-        parameterMap.forEach((s, strings) -> params.addAll(s, s));
+        parameterMap.forEach(params::addAll);
         return params;
     }
 

--- a/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServerSpec.groovy
+++ b/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServerSpec.groovy
@@ -6,6 +6,7 @@ import io.micronaut.http.annotation.Body
 import io.micronaut.http.annotation.Controller
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.Post
+import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.RxHttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.test.annotation.MicronautTest
@@ -45,17 +46,31 @@ class AwsApiProxyTestServerSpec extends Specification {
         result == 'goodbody'
     }
 
+    void 'query values are picked up'() {
+        when:
+        def result = client.retrieve(HttpRequest.GET('/test-param?foo=bar')
+                                        .contentType(MediaType.TEXT_PLAIN), String).blockingFirst()
 
-    @Controller('/test')
+        then:
+            result == 'get:bar'
+    }
+
+
+    @Controller
     static class TestController {
-        @Get(value = '/', produces = MediaType.TEXT_PLAIN)
+        @Get(value = '/test', produces = MediaType.TEXT_PLAIN)
         String test() {
             return 'good'
         }
 
-        @Post(value = '/', processes = MediaType.TEXT_PLAIN)
+        @Post(value = '/test', processes = MediaType.TEXT_PLAIN)
         String test(@Body String body) {
             return 'good' + body
+        }
+
+        @Get(value = '/test-param{?foo}', processes = MediaType.TEXT_PLAIN)
+        String search(@QueryValue String foo) {
+            return 'get:' + foo
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-aws/issues/754 when running `./gradlew run`.

I noticed there are two identical tests in `AwsApiProxyTestServerSpec`. Does that serve a purpose or is it just a mistake ?