### PR TITLE
logging fixes

### DIFF
--- a/aws-alexa-httpserver/src/main/java/io/micronaut/aws/alexa/httpserver/controllers/SkillController.java
+++ b/aws-alexa-httpserver/src/main/java/io/micronaut/aws/alexa/httpserver/controllers/SkillController.java
@@ -106,10 +106,7 @@ public class SkillController {
             }
 
         } catch (IOException e) {
-
-            if (LOG.isErrorEnabled()) {
-                LOG.error("Unable to parse a byte array to RequestEnvelope");
-            }
+            LOG.error("Unable to parse a byte array to RequestEnvelope");
         }
         return HttpResponse.badRequest();
     }

--- a/aws-alexa-httpserver/src/main/java/io/micronaut/aws/alexa/httpserver/exceptions/AskSdkExceptionHandler.java
+++ b/aws-alexa-httpserver/src/main/java/io/micronaut/aws/alexa/httpserver/exceptions/AskSdkExceptionHandler.java
@@ -42,10 +42,7 @@ public class AskSdkExceptionHandler implements ExceptionHandler<AskSdkException,
 
     @Override
     public HttpResponse handle(HttpRequest request, AskSdkException ex) {
-
-        if (LOG.isErrorEnabled()) {
-            LOG.error("Exception occurred processing request envelope, returning status code 500", ex);
-        }
+        LOG.error("Exception occurred processing request envelope, returning status code 500", ex);
         JsonError error = new JsonError(ex.getMessage());
         error.link(Link.SELF, Link.of(request.getUri()));
         return HttpResponse.serverError(error);

--- a/aws-alexa-httpserver/src/main/java/io/micronaut/aws/alexa/httpserver/exceptions/SecurityExceptionHandler.java
+++ b/aws-alexa-httpserver/src/main/java/io/micronaut/aws/alexa/httpserver/exceptions/SecurityExceptionHandler.java
@@ -41,9 +41,7 @@ public class SecurityExceptionHandler implements ExceptionHandler<SecurityExcept
 
     @Override
     public HttpResponse handle(HttpRequest request, SecurityException ex) {
-        if (LOG.isErrorEnabled()) {
-            LOG.error("Incoming request failed verification 400", ex);
-        }
+        LOG.error("Incoming request failed verification 400", ex);
         JsonError error = new JsonError(ex.getMessage());
         error.link(Link.SELF, Link.of(request.getUri()));
         return HttpResponse.badRequest(error);

--- a/aws-common/src/main/java/io/micronaut/discovery/cloud/aws/AmazonComputeInstanceMetadataResolver.java
+++ b/aws-common/src/main/java/io/micronaut/discovery/cloud/aws/AmazonComputeInstanceMetadataResolver.java
@@ -111,16 +111,12 @@ public class AmazonComputeInstanceMetadataResolver implements ComputeInstanceMet
             try {
                 ec2InstanceMetadata.setLocalHostname(readEc2MetadataUrl(new URL(ec2InstanceMetadataURL + EC2MetadataKeys.localHostname.getName()), CONNECTION_TIMEOUT_IN_MILLS, READ_TIMEOUT_IN_MILLS));
             } catch (IOException e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Error getting local hostname from url:" + ec2InstanceMetadataURL + EC2MetadataKeys.localHostname.name(), e);
-                }
+                LOG.error("Error getting local hostname from url:{}{}", ec2InstanceMetadataURL, EC2MetadataKeys.localHostname.name(), e);
             }
             try {
                 ec2InstanceMetadata.setPublicHostname(readEc2MetadataUrl(new URL(ec2InstanceMetadataURL + EC2MetadataKeys.publicHostname.getName()), CONNECTION_TIMEOUT_IN_MILLS, READ_TIMEOUT_IN_MILLS));
             } catch (IOException e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("error getting public host name from:" + ec2InstanceMetadataURL + EC2MetadataKeys.publicHostname.name(), e);
-                }
+                LOG.error("error getting public host name from:{}{}", ec2InstanceMetadataURL, EC2MetadataKeys.publicHostname.name(), e);
             }
             // build up network info
             try {
@@ -139,14 +135,12 @@ public class AmazonComputeInstanceMetadataResolver implements ComputeInstanceMet
                 ec2InstanceMetadata.setInterfaces(new ArrayList<>());
                 ec2InstanceMetadata.getInterfaces().add(networkInterface);
             } catch (IOException e) {
-                LOG.error("error getting public host name from:" + ec2InstanceMetadataURL + EC2MetadataKeys.publicHostname.getName(), e);
+                LOG.error("error getting public host name from:{}{}", ec2InstanceMetadataURL, EC2MetadataKeys.publicHostname.getName(), e);
             }
 
             Map<?, ?> metadata = objectMapper.convertValue(ec2InstanceMetadata, Map.class);
             populateMetadata(ec2InstanceMetadata, metadata);
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("EC2 Metadata found:" + ec2InstanceMetadata.getMetadata().toString());
-            }
+            LOG.debug("EC2 Metadata found:{}", ec2InstanceMetadata.getMetadata());
             //TODO make individual calls for building network interfaces.. required recursive http calls for all mac addresses
         } catch (IOException e) {
             LOG.error("Error reading ec2 metadata url", e);

--- a/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/AWSParameterStoreConfigClient.java
+++ b/aws-parameter-store/src/main/java/io/micronaut/discovery/aws/parameterstore/AWSParameterStoreConfigClient.java
@@ -163,9 +163,7 @@ public class AWSParameterStoreConfigClient implements ConfigurationClient {
     private Maybe<LocalSource> buildLocalSource(ParameterQueryResult queryResult) {
         String key = queryResult.query.getPath();
         if (queryResult.parameters.isEmpty()) {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("parameterBasePath={} no parameters found", key);
-            }
+            LOG.trace("parameterBasePath={} no parameters found", key);
             return Maybe.empty();
         }
         Map<String, Object> properties = convertParametersToMap(queryResult);
@@ -311,9 +309,7 @@ public class AWSParameterStoreConfigClient implements ConfigurationClient {
         if (previous == null) {
             accumulator.put(localSource.name, localSource);
         } else {
-            if (LOG.isTraceEnabled()) {
-                LOG.trace("merging into existing source {} from {}", localSource.name, localSource.priority);
-            }
+            LOG.trace("merging into existing source {} from {}", localSource.name, localSource.priority);
             if (previous.priority != localSource.priority) {
                 LOG.warn("local source {} redeclared with priority {} instead ofg {}, ignoring", localSource.name,
                         localSource.priority, previous.priority);
@@ -326,9 +322,7 @@ public class AWSParameterStoreConfigClient implements ConfigurationClient {
     private static Flowable<PropertySource> toPropertySourcePublisher(Map<String, LocalSource> localSourceMap) {
         return Flowable.fromIterable(localSourceMap.values())
             .map(localSource -> {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace("source={} got priority={}", localSource.name, localSource.priority);
-                }
+                LOG.trace("source={} got priority={}", localSource.name, localSource.priority);
                 return PropertySource.of(Route53ClientDiscoveryConfiguration.SERVICE_ID
                         + '-' + localSource.name, localSource.values, localSource.priority);
             });

--- a/aws-route53/src/main/java/io/micronaut/discovery/aws/route53/registration/Route53AutoNamingRegistrationClient.java
+++ b/aws-route53/src/main/java/io/micronaut/discovery/aws/route53/registration/Route53AutoNamingRegistrationClient.java
@@ -142,9 +142,7 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
             if (instance.getMetadata().contains("instanceId")) {
                 opt = Optional.of(instance.getMetadata().asMap().get("instanceId"));
             } else {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Cannot determine the instance ID. Are you sure you are running on AWS EC2?");
-                }
+                LOG.error("Cannot determine the instance ID. Are you sure you are running on AWS EC2?");
             }
         }
 
@@ -166,7 +164,7 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
 
             if (status.getOperational().isPresent() && !status.getOperational().get()) {
                 getDiscoveryClient().deregisterInstance(new DeregisterInstanceRequest().withInstanceId(instanceId).withServiceId(route53AutoRegistrationConfiguration.getAwsServiceId()));
-                LOG.info("Health status is non operational, instance id " + instanceId + " was de-registered from the discovery service.");
+                LOG.info("Health status is non operational, instance id {} was de-registered from the discovery service.", instanceId);
             }
 
         });
@@ -243,9 +241,7 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
             if (metadata.contains("instanceId")) {
                 instanceId = metadata.asMap().get("instanceId");
             } else {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Cannot determine the instance ID. Are you sure you are running on AWS EC2?");
-                }
+                LOG.error("Cannot determine the instance ID. Are you sure you are running on AWS EC2?");
             }
         }
         RegisterInstanceRequest instanceRequest = new RegisterInstanceRequest().withServiceId(route53AutoRegistrationConfiguration.getAwsServiceId())
@@ -260,9 +256,7 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
 
             @Override
             public void onNext(RegisterInstanceResult registerInstanceResult) {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Called AWS to register service [{}] with {}", instance.getId(), route53AutoRegistrationConfiguration.getAwsServiceId());
-                }
+                LOG.info("Called AWS to register service [{}] with {}", instance.getId(), route53AutoRegistrationConfiguration.getAwsServiceId());
                 if (registerInstanceResult.getOperationId() != null) {
                     ServiceRegistrationStatusTask serviceRegistrationStatusTask = new ServiceRegistrationStatusTask(getDiscoveryClient(),
                             route53AutoRegistrationConfiguration,
@@ -280,9 +274,7 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
 
             @Override
             public void onError(Throwable t) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Error registering instance with AWS:" + t.getMessage(), t);
-                }
+                LOG.error("Error registering instance with AWS: {}", t.getMessage(), t);
                 if (route53AutoRegistrationConfiguration.isFailFast() && instance instanceof EmbeddedServerInstance) {
                     LOG.error("Error registering instance with AWS and Failfast is set: stopping instance");
                     ((EmbeddedServerInstance) instance).getEmbeddedServer().stop();
@@ -291,10 +283,8 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
 
             @Override
             public void onComplete() {
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Success calling register service request [{}] with {} is complete.", instance.getId(),
-                            route53AutoRegistrationConfiguration.getAwsServiceId());
-                }
+                LOG.info("Success calling register service request [{}] with {} is complete.", instance.getId(),
+                        route53AutoRegistrationConfiguration.getAwsServiceId());
             }
         });
 
@@ -380,11 +370,12 @@ public class Route53AutoNamingRegistrationClient extends DiscoveryServiceAutoReg
                 opResult = getDiscoveryClient().getOperation(new GetOperationRequest().withOperationId(operationId));
                 result = opResult.getOperation().getStatus();
                 if (opResult.getOperation().getStatus().equals("SUCCESS")) {
-                    LOG.info("Successfully get operation id " + operationId);
+                    LOG.info("Successfully get operation id {}", operationId);
                     return opResult;
                 } else {
                     if (opResult.getOperation().getStatus().equals("FAIL")) {
-                        LOG.error("Error calling aws service for operationId:" + operationId + " error code:" + opResult.getOperation().getErrorCode() + " error message:" + opResult.getOperation().getErrorMessage());
+                        LOG.error("Error calling aws service for operationId:{} error code:{} error message:{}",
+                                operationId, opResult.getOperation().getErrorCode(), opResult.getOperation().getErrorMessage());
                         return opResult;
                     }
                 }

--- a/aws-route53/src/main/java/io/micronaut/discovery/aws/route53/registration/ServiceRegistrationStatusTask.java
+++ b/aws-route53/src/main/java/io/micronaut/discovery/aws/route53/registration/ServiceRegistrationStatusTask.java
@@ -70,16 +70,12 @@ class ServiceRegistrationStatusTask implements Runnable {
         while (!registered) {
                 GetOperationRequest operationRequest = new GetOperationRequest().withOperationId(operationId);
                 GetOperationResult result = discoveryClient.getOperation(operationRequest);
-                if (LOG.isInfoEnabled()) {
-                    LOG.info("Service registration for operation " + operationId + " resulted in " + result.getOperation().getStatus());
-                }
+                LOG.info("Service registration for operation {} resulted in {}", operationId, result.getOperation().getStatus());
                 if (result.getOperation().getStatus().equalsIgnoreCase("failure") || result.getOperation().getStatus().equalsIgnoreCase("success")) {
                     registered = true; // either way we are done
                     if (result.getOperation().getStatus().equalsIgnoreCase("failure")) {
                         if (route53AutoRegistrationConfiguration.isFailFast() && embeddedServerInstance instanceof EmbeddedServerInstance) {
-                            if (LOG.isErrorEnabled()) {
-                                LOG.error("Error registering instance shutting down instance because failfast is set.");
-                            }
+                            LOG.error("Error registering instance shutting down instance because failfast is set.");
                             ((EmbeddedServerInstance) embeddedServerInstance).getEmbeddedServer().stop();
                         }
                     }
@@ -88,10 +84,7 @@ class ServiceRegistrationStatusTask implements Runnable {
             try {
                 Thread.currentThread().sleep(5000);
             } catch (InterruptedException e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error("Registration monitor service has been aborted, unable to verify proper service registration on Route 53.", e);
-                }
+                LOG.error("Registration monitor service has been aborted, unable to verify proper service registration on Route 53.", e);
             }
         }
-
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AbstractLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AbstractLambdaContainerHandler.java
@@ -206,7 +206,7 @@ public abstract class AbstractLambdaContainerHandler<RequestType, ResponseType, 
 
             latch.await();
 
-            if (logFormatter != null) {
+            if (logFormatter != null && log.isInfoEnabled()) {
                 log.info(SecurityUtils.crlf(logFormatter.format(containerRequest, containerResponse, securityContext)));
             }
 

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautResponseWriter.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautResponseWriter.java
@@ -98,9 +98,7 @@ public class MicronautResponseWriter extends ResponseWriter<MicronautAwsProxyRes
                     awsProxyResponse.setBody(output);
                 }
             } catch (IOException e) {
-                if (LOG.isErrorEnabled()) {
-                    LOG.error(e.getMessage());
-                }
+                LOG.error(e.getMessage());
             }
         } else if (body != null) {
             awsProxyResponse.setBody(


### PR DESCRIPTION
don't use unnecessary log.isEnabled() checks when using SLF4J, use placeholder replacement
avoid unnecessary toString() when logging
reworked LambdaRuntime logging in AbstractMicronautLambdaRuntime to avoid unnecessary string concatenation