### PR TITLE
build: root already adds ann micronaut-graal

### DIFF
--- a/aws-parameter-store/build.gradle
+++ b/aws-parameter-store/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
-    annotationProcessor "io.micronaut:micronaut-graal"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:1.0.25"
 
     api 'io.micronaut.discovery:micronaut-discovery-client:2.3.0'

--- a/aws-route53/build.gradle
+++ b/aws-route53/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
-    annotationProcessor "io.micronaut:micronaut-graal"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:1.0.25"
 
     api 'io.micronaut.discovery:micronaut-discovery-client:2.3.0'

--- a/function-aws-api-proxy/build.gradle
+++ b/function-aws-api-proxy/build.gradle
@@ -1,8 +1,7 @@
 dependencies {
     annotationProcessor "io.micronaut:micronaut-inject-java"
     annotationProcessor "io.micronaut.docs:micronaut-docs-asciidoc-config-props:1.0.25"
-    annotationProcessor "io.micronaut:micronaut-graal"
-
+    
     compileOnly "io.micronaut.security:micronaut-security:$micronautSecurity"
 
     implementation "io.micronaut:micronaut-http-netty"


### PR DESCRIPTION
delete annotationProcessor micronaut-graal from subprojects because it is already applied to every subproject at root build file.