### PR TITLE
doc: Object Mapper Configuration

### DIFF
--- a/src/main/docs/guide/lambda/objectmapperconfiguration.adoc
+++ b/src/main/docs/guide/lambda/objectmapperconfiguration.adoc
@@ -1,0 +1,4 @@
+By default, for efficiency reasons, Micronaut uses the default Jackson `ObjectMapper` to communicate with the AWS API proxy. However, if you have configured it for your application (for example, setting `jackson.propertyNamingStrategy: SNAKE_CASE`)
+ in a way that it would be incompatible with the API proxy, you can set `aws.proxy.shared-object-mapper: false`, and Micronaut will create a brand new `ObjectMapper` for the API proxy.
+
+If you wish to further configure this `ObjectMapper`, you can register a `BeanCreatedEventListener<ObjectMapper>` and filter based on `event.getBeanDefinition()` having an annotation like `@Named("aws")`.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -43,6 +43,7 @@ lambda:
   mdc: MDC Logging
   lambdaTutorials: Micronaut AWS Lambda Tutorials
   lambdaTesting: Testing Lambda Handlers
+  objectmapperconfiguration: Object Mapper Configuration
 alexa:
   title: Alexa Support
   alexaskillconfiguration: Alexa Skill Configuration


### PR DESCRIPTION
This recovers this snippet of documentation which was introduced here:

https://github.com/micronaut-projects/micronaut-aws/pull/195/files

and accidentally deleted here:

https://github.com/micronaut-projects/micronaut-aws/pull/471