### PR TITLE
build: bump up to Micronaut 3.0.0-M5

### DIFF
--- a/function-aws-alexa/src/main/java/io/micronaut/function/aws/alexa/AlexaFunction.java
+++ b/function-aws-alexa/src/main/java/io/micronaut/function/aws/alexa/AlexaFunction.java
@@ -67,7 +67,7 @@ public class AlexaFunction implements RequestStreamHandler, AutoCloseable, Close
     @SuppressWarnings("unchecked")
     @NonNull
     protected ApplicationContextBuilder newApplicationContextBuilder() {
-        return ApplicationContext.build(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, AlexaEnvironment.ENV_ALEXA)
+        return ApplicationContext.builder(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, AlexaEnvironment.ENV_ALEXA)
                 .eagerInitSingletons(true)
                 .eagerInitConfiguration(true);
     }

--- a/function-aws-api-proxy/build.gradle
+++ b/function-aws-api-proxy/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testImplementation "io.micronaut:micronaut-http-client"
     testImplementation "io.micronaut.security:micronaut-security:$micronautSecurity"
 
-    testImplementation "io.micronaut.views:micronaut-views-handlebars:$micronautViewsVersion"
+    testImplementation "io.micronaut.views:micronaut-views-handlebars"
 
     testImplementation 'com.fasterxml.jackson.module:jackson-module-afterburner'
     testImplementation 'javax.servlet:servlet-api:2.5'

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/MicronautAwsProxyTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/MicronautAwsProxyTest.java
@@ -74,7 +74,7 @@ public class MicronautAwsProxyTest {
     public static void initHandler() {
         try {
             handler = new MicronautLambdaContainerHandler(
-                    ApplicationContext.build(CollectionUtils.mapOf(
+                    ApplicationContext.builder(CollectionUtils.mapOf(
                             "spec.name", "MicronautAwsProxyTest",
                             "micronaut.security.enabled", true,
                             "micronaut.views.handlebars.enabled", true,
@@ -219,7 +219,7 @@ public class MicronautAwsProxyTest {
     @Test
     public void errors_unknownRoute_expect404() throws ContainerInitializationException {
         MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
-                ApplicationContext.build(CollectionUtils.mapOf(
+                ApplicationContext.builder(CollectionUtils.mapOf(
                         "spec.name", "MicronautAwsProxyTest",
                         "micronaut.security.enabled", false,
                         "micronaut.views.handlebars.enabled", true,
@@ -236,7 +236,7 @@ public class MicronautAwsProxyTest {
     @Test
     public void error_statusCode_methodNotAllowed() throws ContainerInitializationException {
         MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
-                ApplicationContext.build(CollectionUtils.mapOf(
+                ApplicationContext.builder(CollectionUtils.mapOf(
                         "spec.name", "MicronautAwsProxyTest",
                         "micronaut.security.enabled", false,
                         "micronaut.views.handlebars.enabled", true,
@@ -359,7 +359,7 @@ public class MicronautAwsProxyTest {
     @Test
     public void stripBasePath_route_shouldReturn404() throws ContainerInitializationException {
         MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
-                ApplicationContext.build(CollectionUtils.mapOf(
+                ApplicationContext.builder(CollectionUtils.mapOf(
                         "spec.name", "MicronautAwsProxyTest",
                         "micronaut.security.enabled", false,
                         "micronaut.views.handlebars.enabled", true,

--- a/function-client-aws/src/test/groovy/io/micronaut/function/client/aws/LocalFunctionInvokeSpec.groovy
+++ b/function-client-aws/src/test/groovy/io/micronaut/function/client/aws/LocalFunctionInvokeSpec.groovy
@@ -26,7 +26,6 @@ import io.micronaut.runtime.server.EmbeddedServer
 //tag::rxImport[]
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
-import spock.lang.PendingFeature
 
 //end::rxImport[]
 import spock.lang.Specification
@@ -37,7 +36,6 @@ import spock.lang.Specification
  */
 class LocalFunctionInvokeSpec extends Specification {
 
-    @PendingFeature
     //tag::invokeLocalFunction[]
     void "test invoking a local function"() {
         given:
@@ -51,8 +49,7 @@ class LocalFunctionInvokeSpec extends Specification {
 
     }
     //end::invokeLocalFunction[]
-
-    @PendingFeature
+    
     //tag::invokeRxLocalFunction[]
     void "test invoking a local function - rx"() {
         given:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,6 @@ groovyVersion=3.0.8
 spockVersion=2.0-groovy-3.0
 askVersion=2.38.1
 micronautSecurity=3.0.0-M2
-micronautViewsVersion=3.0.0-M1
 
 title=Micronaut AWS
 projectDesc=Provides integration between Micronaut and Amazon Web Services (AWS)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 projectVersion=3.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautDiscoveryClientVersion=3.0.0-M1
 micronautVersion=3.0.0-M5
 micronautTestVersion=3.0.0-RC2
 groovyVersion=3.0.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 projectVersion=3.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautVersion=3.0.0-M4
 micronautTestVersion=2.3.7
 micronautDiscoveryClientVersion=3.0.0-M1
+micronautVersion=3.0.0-M5
 groovyVersion=3.0.8
 spockVersion=2.0-groovy-3.0
 askVersion=2.38.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 projectVersion=3.0.0-SNAPSHOT
 micronautDocsVersion=2.0.0.RC1
-micronautTestVersion=2.3.7
 micronautDiscoveryClientVersion=3.0.0-M1
 micronautVersion=3.0.0-M5
+micronautTestVersion=3.0.0-RC2
 groovyVersion=3.0.8
 spockVersion=2.0-groovy-3.0
 askVersion=2.38.1


### PR DESCRIPTION
- replace ApplicationContext.:build with ctx::builder
- bump up micronaut to 3.0.0-M5
- bump up micronaut test 3.0.0-RC2
- remove @PendingFeature
- don't specify views version
- build:del property micronautDiscoveryClientVersion

Close: https://github.com/micronaut-projects/micronaut-aws/pull/1138/files