### PR TITLE
BREAKING CHANGE: micronaut.function.name precedence

### DIFF
--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.env.Environment;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.function.executor.StreamFunctionExecutor;
 import io.micronaut.core.annotation.NonNull;
 import java.io.IOException;
@@ -36,7 +37,8 @@ import static io.micronaut.function.aws.MicronautRequestHandler.registerContextB
  */
 public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Context> implements RequestStreamHandler, MicronautLambdaContext {
 
-    private String functionName;
+    @Nullable
+    private String ctxFunctionName;
 
     /**
      * Default constructor; will initialize a suitable {@link ApplicationContext} for
@@ -67,7 +69,7 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
         ApplicationContext applicationContext = super.buildApplicationContext(context);
         if (context != null) {
             registerContextBeans(context, applicationContext);
-            this.functionName = context.getFunctionName();
+            this.ctxFunctionName = context.getFunctionName();
         }
         return applicationContext;
     }
@@ -80,10 +82,7 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
 
     @Override
     protected String resolveFunctionName(Environment env) {
-        if (this.functionName != null) {
-            return functionName;
-        } else {
-            return super.resolveFunctionName(env);
-        }
+        String functionName = super.resolveFunctionName(env);
+        return (functionName != null) ? functionName : ctxFunctionName;
     }
 }

--- a/src/main/docs/guide/lambda/lambdaStreamHandler.adoc
+++ b/src/main/docs/guide/lambda/lambdaStreamHandler.adoc
@@ -17,7 +17,7 @@ snippet::io.micronaut.docs.function.aws.EventLogger[tags="clazz"]
 
 A single project can define multiple functions, however only a single function should be configured for execution by the application.
 
-By default, it is resolved from the function name present in the Lambda Context, the name of the function on the AWS Console. If the function name cannot be resolved via the Lambda Context the property `micronaut.function.name` is used.
+By default, it is resolved via the property `micronaut.function.name`. If not present, the function name present in the Lambda Context, the name of the function on the AWS Console, is used.
 
 Alternatively, you can write a custom Handler which extends api:function.aws.MicronautRequestStreamHandler[] and overrides `MicronautRequestStreamHandler::resolveFunctionName(Environment)`
 

--- a/src/main/docs/guide/mnawsthree/mnawsthreeBreaks.adoc
+++ b/src/main/docs/guide/mnawsthree/mnawsthreeBreaks.adoc
@@ -13,3 +13,7 @@ If you had code, such as `@IntentHandler("HelloWorldIntent")`, you need to imple
 public boolean canHandle(HandlerInput handlerInput) {
 return handlerInput.matches(Predicates.intentName("HelloWorldIntent"));
 }
+
+== Micronaut Function Name
+
+Property `micronaut.function.name` takes precedence over the function name present in the Lambda Context.

--- a/test-suite/src/test/groovy/io/micronaut/docs/function/aws/ContextFunctionNameSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/docs/function/aws/ContextFunctionNameSpec.groovy
@@ -10,8 +10,7 @@ import spock.lang.Specification
 class ContextFunctionNameSpec extends Specification {
     void "Context::getFunctionName has priority over micronaut.function.name property"() {
         given:
-        ApplicationContext ctx = ApplicationContext.run(['micronaut.function.name': 'capitalize'])
-        MicronautRequestStreamHandler handler = new MicronautRequestStreamHandler(ctx)
+        MicronautRequestStreamHandler handler = new MicronautRequestStreamHandler()
 
         when:
         String input = 'jOHn'

--- a/test-suite/src/test/groovy/io/micronaut/docs/function/aws/MicronautFunctionNameSpec.groovy
+++ b/test-suite/src/test/groovy/io/micronaut/docs/function/aws/MicronautFunctionNameSpec.groovy
@@ -20,7 +20,9 @@ class MicronautFunctionNameSpec extends Specification {
         handler.handleRequest(
                 inputStream,
                 output,
-                Mock(Context)
+                Stub(Context) {
+                    getFunctionName() >> 'uppercase'
+                }
         )
 
         then:


### PR DESCRIPTION
Property `micronaut.function.name` takes precedence over the function name present in the Lambda Context.

I consider the current default probably a bug. Since the Lambda Context Function name is "always" present.  Because of that, I have swapped the precedence for the next mayor version of Micronaut AWS. 