### PR TITLE
fix: `function` `lamdba` default environments

### DIFF
--- a/function-aws-alexa/src/main/java/io/micronaut/function/aws/alexa/AlexaFunction.java
+++ b/function-aws-alexa/src/main/java/io/micronaut/function/aws/alexa/AlexaFunction.java
@@ -67,7 +67,8 @@ public class AlexaFunction implements RequestStreamHandler, AutoCloseable, Close
     @SuppressWarnings("unchecked")
     @NonNull
     protected ApplicationContextBuilder newApplicationContextBuilder() {
-        return ApplicationContext.builder(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, AlexaEnvironment.ENV_ALEXA)
+        return ApplicationContext.builder()
+                .defaultEnvironments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, AlexaEnvironment.ENV_ALEXA)
                 .eagerInitSingletons(true)
                 .eagerInitConfiguration(true);
     }

--- a/function-aws-alexa/src/test/groovy/io/micronaut/function/aws/alexa/AlexaFunctionEnvironmentSpec.groovy
+++ b/function-aws-alexa/src/test/groovy/io/micronaut/function/aws/alexa/AlexaFunctionEnvironmentSpec.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.function.aws.alexa
+
+import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class AlexaFunctionEnvironmentSpec extends Specification {
+    @RestoreSystemProperties
+    void "function and lambda are the default environments"() {
+        given: "don't deduce environments so that test environment is not detected"
+        System.setProperty(Environment.DEDUCE_ENVIRONMENT_PROPERTY, StringUtils.FALSE)
+        AlexaFunction function = new AlexaFunction()
+
+        expect:
+        ['function', 'lambda', 'alexa'] as Set<String> == function.applicationContext.environment.activeNames
+    }
+
+    @RestoreSystemProperties
+    void "if the user provides an environment, alexa function does not used default environments and uses what the user provided"() {
+        given:
+        System.setProperty(Environment.ENVIRONMENTS_PROPERTY, "foo")
+        AlexaFunction function = new AlexaFunction()
+
+        expect:
+        ['foo', 'test'] as Set<String> == function.applicationContext.environment.activeNames
+    }
+}

--- a/function-aws-test/src/test/java/io/micronaut/function/aws/test/CustomBuilderTest.java
+++ b/function-aws-test/src/test/java/io/micronaut/function/aws/test/CustomBuilderTest.java
@@ -17,7 +17,7 @@ public class CustomBuilderTest {
 
     @Test
     public void testContextProperlyConfigured() {
-        Set<String> expectedNames = new HashSet<>(Arrays.asList("test", "function", "lambda", "custom-env"));
+        Set<String> expectedNames = new HashSet<>(Arrays.asList("test", "custom-env"));
         assertEquals(context.getEnvironment().getActiveNames(), expectedNames);
         assertEquals(Optional.of("baz"), context.getProperty("test.first", String.class));
         assertEquals(Optional.of("bar"), context.getProperty("test.second", String.class));

--- a/function-aws-test/src/test/java/io/micronaut/function/aws/test/MicronautLambdaExtensionTest.java
+++ b/function-aws-test/src/test/java/io/micronaut/function/aws/test/MicronautLambdaExtensionTest.java
@@ -21,7 +21,7 @@ public class MicronautLambdaExtensionTest {
 
     @Test
     public void testContextProperlyConfigured() {
-        Set<String> expectedNames = new HashSet<>(Arrays.asList("test", "function", "lambda"));
+        Set<String> expectedNames = new HashSet<>(Arrays.asList("test"));
         assertNotNull(context);
         assertEquals(context.getEnvironment().getActiveNames(), expectedNames);
         Collection<BeanRegistration<EagerSingleton>> registrations =

--- a/function-aws/src/main/java/io/micronaut/function/aws/LambdaApplicationContextBuilder.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/LambdaApplicationContextBuilder.java
@@ -32,7 +32,7 @@ public class LambdaApplicationContextBuilder extends DefaultApplicationContextBu
 
     public static void setLambdaConfiguration(ApplicationContextBuilder builder) {
         builder
-            .environments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA)
+            .defaultEnvironments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA)
             .eagerInitConfiguration(true)
             .eagerInitSingletons(true);
     }

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/DefaultEnvironmentsSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/DefaultEnvironmentsSpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.function.aws
+
+import io.micronaut.context.env.Environment
+import io.micronaut.core.util.StringUtils
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class DefaultEnvironmentsSpec extends Specification {
+
+    @RestoreSystemProperties
+    void "function and lambda are the default environments"() {
+        given: "don't deduce environments so that test environment is not detected"
+        System.setProperty(Environment.DEDUCE_ENVIRONMENT_PROPERTY, StringUtils.FALSE)
+        MockHandler handler = new MockHandler()
+
+        expect:
+        ['function', 'lambda'] as Set<String> == handler.applicationContext.environment.activeNames
+    }
+
+    @RestoreSystemProperties
+    void "if the user provides an environment lambda and function are not registered as environments"() {
+        given:
+        System.setProperty(Environment.ENVIRONMENTS_PROPERTY, "foo")
+        MockHandler handler = new MockHandler()
+
+        expect:
+        ['foo', 'test'] as Set<String> == handler.applicationContext.environment.activeNames
+    }
+
+    static class MockHandler extends MicronautRequestHandler<Void, Void> {
+
+        @Override
+        Void execute(Void input) {
+            return null
+        }
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestHandlerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestHandlerSpec.groovy
@@ -58,7 +58,6 @@ class MicronautRequestHandlerSpec extends Specification {
 
         @Override
         Integer execute(Float input) {
-            assert env.activeNames.contains(Environment.FUNCTION)
             assert env.activeNames.contains("foo")
             return mathService.round(input)
         }


### PR DESCRIPTION
Closes #1171

Currently `lambda` and `function` are set and the user cannot disable those via system property or environment property (the latter is probably what they want to do as that it is easy to do in the AWS Lambda console). When you deploy to Lambda `lambda` `function` `ec2` and `cloud` are the active environments.

This PR considers  `lambda` and `function` default environments. Hence, if the user specifies for example `MICRONAUT_ENVIRONMENTS=prod` in the AWS console, the active environment for the lambda function will be only `prod`.

The only drawback is that right now in the test classpath `function`, `lambda` and `test` are the active environments with PR only `test` is the active enviroments. Default enviroments are not used if an environment is deduced.

I consider the current behaviour a bug and I think we should fix it even if we remove `lambda` and `function` for the tests.