### PR TITLE
fix: don't apply security filter again

### DIFF
--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ErrorHandlerSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ErrorHandlerSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.function.aws.proxy
 
 import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder
 import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse
 import com.amazonaws.services.lambda.runtime.Context
 import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.transform.InheritConstructors
@@ -14,6 +15,8 @@ import io.micronaut.http.codec.CodecException
 import io.micronaut.http.hateoas.JsonError
 import io.micronaut.http.hateoas.Link
 import io.micronaut.http.server.exceptions.ExceptionHandler
+import io.micronaut.security.annotation.Secured
+import io.micronaut.security.rules.SecurityRule
 import spock.lang.AutoCleanup
 import spock.lang.Issue
 import spock.lang.PendingFeature
@@ -31,7 +34,6 @@ class ErrorHandlerSpec extends Specification {
     @AutoCleanup
     MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
             ApplicationContext.builder().properties([
-                    'micronaut.security.enabled': false,
                     'spec.name': 'ErrorHandlerSpec',
                     'micronaut.server.cors.enabled': true,
                     'micronaut.server.cors.configurations.web.allowedOrigins': ['http://localhost:8080']
@@ -166,6 +168,18 @@ class ErrorHandlerSpec extends Specification {
         response.multiValueHeaders.getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN) == 'http://localhost:8080'
     }
 
+    void 'secured controller returns 401'() {
+        given:
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/secret', HttpMethod.GET.toString())
+                .header(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN)
+
+        when:
+        AwsProxyResponse response = handler.proxy(builder.build(), lambdaContext)
+
+        then:
+        response.statusCode == 401
+    }
+
     void 'cors headers are present after failed deserialisation when error handler is used'() {
         given:
         AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/json/errors/global', HttpMethod.POST.toString())
@@ -179,6 +193,18 @@ class ErrorHandlerSpec extends Specification {
         response.multiValueHeaders.getFirst(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN) == 'http://localhost:8080'
     }
 
+    @Secured(SecurityRule.IS_AUTHENTICATED)
+    @Controller('/secret')
+    @Requires(property = 'spec.name', value = 'ErrorHandlerSpec')
+    static class SecretController {
+        @Get
+        @Produces(MediaType.TEXT_PLAIN)
+        String index() {
+            "area 51 hosts an alien"
+        }
+    }
+
+    @Secured(SecurityRule.IS_ANONYMOUS)
     @Controller('/errors')
     @Requires(property = 'spec.name', value = 'ErrorHandlerSpec')
     static class ErrorController {
@@ -211,6 +237,7 @@ class ErrorHandlerSpec extends Specification {
         }
     }
 
+    @Secured(SecurityRule.IS_ANONYMOUS)
     @Issue("issues/761")
     @Controller(value = '/json/errors', produces = io.micronaut.http.MediaType.APPLICATION_JSON)
     @Requires(property = 'spec.name', value = 'ErrorHandlerSpec')
@@ -242,6 +269,7 @@ class ErrorHandlerSpec extends Specification {
         }
     }
 
+    @Secured(SecurityRule.IS_ANONYMOUS)
     @Controller('/json')
     @Requires(property = 'spec.name', value = 'ErrorHandlerSpec')
     static class JsonController {
@@ -251,6 +279,7 @@ class ErrorHandlerSpec extends Specification {
         }
     }
 
+    @Secured(SecurityRule.IS_ANONYMOUS)
     @Controller('/global-errors')
     @Requires(property = 'spec.name', value = 'ErrorHandlerSpec')
     static class GlobalErrorController {


### PR DESCRIPTION
Close #1166 

I don't think this is the right fix. However, it fullfil the test. 

I tried not applying the filters after an exception but that breaks all the CORS headers valid present even if exception. 

