### PR TITLE
Bump build plugins

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,3 @@
-buildscript {
-    repositories {
-        mavenCentral()
-        gradlePluginPortal()
-    }
-    dependencies {
-        classpath "io.micronaut.build.internal:micronaut-gradle-plugins:4.2.1"
-    }
-}
-
 subprojects { Project subproject ->
 
     group "io.micronaut.aws"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,14 @@
-plugins {
-    id "com.gradle.enterprise" version "3.6.1"
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
 }
+
+plugins {
+    id 'io.micronaut.build.shared.settings' version '4.2.2'
+}
+
 
 rootProject.name = 'aws'
 
@@ -24,12 +32,4 @@ include 'function-aws-test'
 include 'test-suite'
 include 'test-suite-groovy'
 include 'test-suite-kotlin'
-
-gradleEnterprise {
-    buildScan {
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
-        publishAlways()
-    }
-}
 


### PR DESCRIPTION
This updates the build plugins to 4.2.2, which will also
enable build scans.