### PR TITLE
Send a user-agent header with requests to the Lambda Runtime API.

### DIFF
--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
@@ -35,11 +35,13 @@ import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.cli.CommandLine;
 import io.micronaut.core.reflect.ClassUtils;
 import io.micronaut.core.reflect.GenericTypeUtils;
+import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.MicronautLambdaContext;
 import io.micronaut.function.aws.MicronautRequestHandler;
 import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
@@ -58,6 +60,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import static io.micronaut.http.HttpHeaders.USER_AGENT;
 
 /**
  * Class that can be used as a entry point for a AWS Lambda custom runtime.
@@ -96,6 +100,11 @@ import java.util.function.Predicate;
 )
 public abstract class AbstractMicronautLambdaRuntime<RequestType, ResponseType, HandlerRequestType, HandlerResponseType>
         implements ApplicationContextProvider, AwsLambdaRuntimeApi {
+
+    static final String USER_AGENT_VALUE = String.format(
+            "micronaut/%s-%s",
+            System.getProperty("java.vendor.version"),
+            AbstractMicronautLambdaRuntime.class.getPackage().getImplementationVersion());
 
     protected Object handler;
 
@@ -327,7 +336,8 @@ public abstract class AbstractMicronautLambdaRuntime<RequestType, ResponseType, 
             final BlockingHttpClient blockingHttpClient = endpointClient.toBlocking();
             try {
                 while (loopUntil.test(runtimeApiURL)) {
-                    final HttpResponse<RequestType> response = blockingHttpClient.exchange(AwsLambdaRuntimeApi.NEXT_INVOCATION_URI, requestType);
+                    final HttpResponse<RequestType> response = blockingHttpClient.exchange(
+                            HttpRequest.GET(AwsLambdaRuntimeApi.NEXT_INVOCATION_URI).header(USER_AGENT, USER_AGENT_VALUE), Argument.of(requestType));
                     final RequestType request = response.body();
                     if (request != null) {
                         logn(LogLevel.DEBUG, "request body ", request);

--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AwsLambdaRuntimeApi.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AwsLambdaRuntimeApi.java
@@ -22,6 +22,9 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import java.util.Collections;
 
+import static io.micronaut.function.aws.runtime.AbstractMicronautLambdaRuntime.USER_AGENT_VALUE;
+import static io.micronaut.http.HttpHeaders.USER_AGENT;
+
 /**
  * @see <a href="https://docs.aws.amazon.com/lambda/latest/dg/runtimes-api.html">AWS Lambda Runtime Interface</a>
  * @author sdelamo
@@ -63,7 +66,7 @@ public interface AwsLambdaRuntimeApi {
      * @return Invocation Response Request
      */
     default HttpRequest invocationResponseRequest(@NonNull String requestId, Object body) {
-        return HttpRequest.POST(responseUri(requestId), body);
+        return HttpRequest.POST(responseUri(requestId), body).header(USER_AGENT, USER_AGENT_VALUE);
     }
 
     /**
@@ -79,7 +82,7 @@ public interface AwsLambdaRuntimeApi {
                                                                         @Nullable String errorType,
                                                                         @Nullable String lambdaFunctionErrorType) {
         AwsLambdaRuntimeApiError error = new AwsLambdaRuntimeApiError(errorMessage, errorType);
-        MutableHttpRequest<AwsLambdaRuntimeApiError> request = HttpRequest.POST(errorUri(requestId), error);
+        MutableHttpRequest<AwsLambdaRuntimeApiError> request = HttpRequest.POST(errorUri(requestId), error).header(USER_AGENT, USER_AGENT_VALUE);
         if (lambdaFunctionErrorType != null) {
             return request.header(LAMBDA_RUNTIME_FUNCTION_ERROR_TYPE, lambdaFunctionErrorType);
         }
@@ -97,7 +100,7 @@ public interface AwsLambdaRuntimeApi {
                                                                             @Nullable String errorType,
                                                                             @Nullable String lambdaFunctionErrorType) {
         AwsLambdaRuntimeApiError error = new AwsLambdaRuntimeApiError(errorMessage, errorType);
-        MutableHttpRequest<AwsLambdaRuntimeApiError> request = HttpRequest.POST(INIT_ERROR_URI, error);
+        MutableHttpRequest<AwsLambdaRuntimeApiError> request = HttpRequest.POST(INIT_ERROR_URI, error).header(USER_AGENT, USER_AGENT_VALUE);
         if (lambdaFunctionErrorType != null) {
             return request.header(LAMBDA_RUNTIME_FUNCTION_ERROR_TYPE, lambdaFunctionErrorType);
         }


### PR DESCRIPTION
An update to the AbstractMicronautLambdaRuntime and AwsLambdaRuntimeApi to send the version of Java and the version of Micronaut as the user-agent information in the HTTP request header.