### PR TITLE
Register Lambda Context as singletons and MDC for every Handler

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -36,6 +36,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.TypeVariableResolver;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.function.aws.DiagnosticInfoPopulator;
 import io.micronaut.function.aws.LambdaApplicationContextBuilder;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpMethod;
@@ -121,6 +122,7 @@ public final class MicronautLambdaContainerHandler
     private Router router;
     private ErrorResponseProcessor errorResponseProcessor;
     private RouteExecutor routeExecutor;
+    private DiagnosticInfoPopulator diagnosticInfoPopulator;
 
     /**
      * Default constructor.
@@ -174,6 +176,7 @@ public final class MicronautLambdaContainerHandler
         ArgumentUtils.requireNonNull("applicationContextBuilder", applicationContextBuilder);
         this.lambdaContainerEnvironment = lambdaContainerEnvironment;
         this.applicationContextBuilder = applicationContextBuilder;
+        this.diagnosticInfoPopulator = new DiagnosticInfoPopulator();
 
         if (applicationContext == null) {
             initialize();
@@ -303,6 +306,10 @@ public final class MicronautLambdaContainerHandler
             MicronautAwsProxyResponse<?> containerResponse,
             Context lambdaContext) {
         Timer.start(TIMER_REQUEST);
+
+        diagnosticInfoPopulator.populateMappingDiagnosticContextValues(lambdaContext);
+        diagnosticInfoPopulator.populateMappingDiagnosticContextWithXrayTraceId();
+
         try {
             ServerRequestContext.with(containerRequest, () -> {
                 Optional<UriRouteMatch> routeMatch = containerRequest.getAttribute(HttpAttributes.ROUTE_MATCH, UriRouteMatch.class);

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -36,7 +36,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.TypeVariableResolver;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.function.aws.DiagnosticInfoPopulator;
+import io.micronaut.function.aws.HandlerUtils;
 import io.micronaut.function.aws.LambdaApplicationContextBuilder;
 import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpMethod;
@@ -122,7 +122,6 @@ public final class MicronautLambdaContainerHandler
     private Router router;
     private ErrorResponseProcessor errorResponseProcessor;
     private RouteExecutor routeExecutor;
-    private DiagnosticInfoPopulator diagnosticInfoPopulator;
 
     /**
      * Default constructor.
@@ -176,7 +175,6 @@ public final class MicronautLambdaContainerHandler
         ArgumentUtils.requireNonNull("applicationContextBuilder", applicationContextBuilder);
         this.lambdaContainerEnvironment = lambdaContainerEnvironment;
         this.applicationContextBuilder = applicationContextBuilder;
-        this.diagnosticInfoPopulator = new DiagnosticInfoPopulator();
 
         if (applicationContext == null) {
             initialize();
@@ -306,9 +304,7 @@ public final class MicronautLambdaContainerHandler
             MicronautAwsProxyResponse<?> containerResponse,
             Context lambdaContext) {
         Timer.start(TIMER_REQUEST);
-
-        diagnosticInfoPopulator.populateMappingDiagnosticContextValues(lambdaContext);
-        diagnosticInfoPopulator.populateMappingDiagnosticContextWithXrayTraceId();
+        HandlerUtils.configureWithContext(this, lambdaContext);
 
         try {
             ServerRequestContext.with(containerRequest, () -> {

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaHandler.java
@@ -65,6 +65,7 @@ public class MicronautLambdaHandler implements RequestHandler<AwsProxyRequest, A
 
     @Override
     public AwsProxyResponse handleRequest(AwsProxyRequest input, Context context) {
+
         return handler.proxy(input, context);
     }
 

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/LambdaContextSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/LambdaContextSpec.groovy
@@ -98,180 +98,23 @@ class LambdaContextSpec extends Specification {
         }
     }
 
-    static Context createContextWithoutCollaborators() {
-        new Context() {
-            @Override
-            String getAwsRequestId() {
-                'XXX'
-            }
-
-            @Override
-            String getLogGroupName() {
-                null
-            }
-
-            @Override
-            String getLogStreamName() {
-                null
-            }
-
-            @Override
-            String getFunctionName() {
-                null
-            }
-
-            @Override
-            String getFunctionVersion() {
-                null
-            }
-
-            @Override
-            String getInvokedFunctionArn() {
-                null
-            }
-
-            @Override
-            CognitoIdentity getIdentity() {
-                null
-            }
-
-            @Override
-            ClientContext getClientContext() {
-                null
-            }
-
-            @Override
-            int getRemainingTimeInMillis() {
-                return 0
-            }
-
-            @Override
-            int getMemoryLimitInMB() {
-                return 0
-            }
-
-            @Override
-            LambdaLogger getLogger() {
-                null
-            }
+    Context createContextWithoutCollaborators() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> null
+            getClientContext() >> null
+            getClientContext() >> null
+            getLogger() >> null
         }
     }
-    static Context createContext() {
-        return new Context() {
-            @Override
-            String getAwsRequestId() {
-                return "XXX"
-            }
 
-            @Override
-            String getLogGroupName() {
-                null
-            }
-
-            @Override
-            String getLogStreamName() {
-                null
-            }
-
-            @Override
-            String getFunctionName() {
-                null
-            }
-
-            @Override
-            String getFunctionVersion() {
-                null
-            }
-
-            @Override
-            String getInvokedFunctionArn() {
-                null
-            }
-
-            @Override
-            CognitoIdentity getIdentity() {
-                new CognitoIdentity() {
-                    @Override
-                    String getIdentityId() {
-                        return "identityIDXXX"
-                    }
-
-                    @Override
-                    String getIdentityPoolId() {
-                        return "identityPoolIdXXX"
-                    }
-                }
-            }
-
-            @Override
-            ClientContext getClientContext() {
-                new ClientContext() {
-                    @Override
-                    Client getClient() {
-                        return new Client() {
-                            @Override
-                            String getInstallationId() {
-                                return "installationId"
-                            }
-
-                            @Override
-                            String getAppTitle() {
-                                null
-                            }
-
-                            @Override
-                            String getAppVersionName() {
-                                null
-                            }
-
-                            @Override
-                            String getAppVersionCode() {
-                                null
-                            }
-
-                            @Override
-                            String getAppPackageName() {
-                                null
-                            }
-                        }
-                    }
-
-                    @Override
-                    Map<String, String> getCustom() {
-                        null
-                    }
-
-                    @Override
-                    Map<String, String> getEnvironment() {
-                        null
-                    }
-                }
-            }
-
-            @Override
-            int getRemainingTimeInMillis() {
-                return 0
-            }
-
-            @Override
-            int getMemoryLimitInMB() {
-                return 0
-            }
-
-            @Override
-            LambdaLogger getLogger() {
-                return new LambdaLogger() {
-                    @Override
-                    void log(String message) {
-
-                    }
-
-                    @Override
-                    void log(byte[] message) {
-
-                    }
-                }
-            }
+    Context createContext() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> Mock(CognitoIdentity)
+            getClientContext() >> Mock(ClientContext)
+            getClientContext() >> Mock(ClientContext)
+            getLogger() >> Mock(LambdaLogger)
         }
     }
 }

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/LambdaContextSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/LambdaContextSpec.groovy
@@ -1,0 +1,277 @@
+package io.micronaut.function.aws.proxy
+
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse
+import com.amazonaws.services.lambda.runtime.*
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.BeanProvider
+import io.micronaut.context.annotation.Any
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.util.CollectionUtils
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class LambdaContextSpec extends Specification {
+
+    void "Lambda Context beans are registered"() {
+        given:
+        Map<String, Object> properties = CollectionUtils.mapOf('micronaut.security.enabled', false, "spec.name", "LambdaContextSpec")
+        ApplicationContextBuilder ctxBuilder = ApplicationContext.builder().properties(properties)
+        MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(ctxBuilder)
+
+        when:
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/context', HttpMethod.GET.toString())
+        AwsProxyResponse response = handler.proxy(builder.build(), createContext())
+
+        then:
+        handler.applicationContext.containsBean(Context)
+        handler.applicationContext.containsBean(LambdaLogger)
+        handler.applicationContext.containsBean(CognitoIdentity)
+        handler.applicationContext.containsBean(ClientContext)
+        "XXX" == response.body
+    }
+
+    void "verify LambdaLogger CognitoIdentity and ClientContext are not registered if null"() {
+        given:
+        Map<String, Object> properties = CollectionUtils.mapOf('micronaut.security.enabled', false, "spec.name", "LambdaContextSpec")
+        ApplicationContextBuilder ctxBuilder = ApplicationContext.builder().properties(properties)
+        MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(ctxBuilder)
+
+        when:
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/context', HttpMethod.GET.toString())
+        AwsProxyResponse response = handler.proxy(builder.build(), createContextWithoutCollaborators())
+
+        then:
+        handler.applicationContext.containsBean(Context)
+        and: 'LambdaLogger is not registered if Lambda Context::getLambdaLogger is null'
+        !handler.applicationContext.containsBean(LambdaLogger)
+
+        and: 'CognitoIdentity is not registered if Lambda Context::getIdentity is null"'
+        !handler.applicationContext.containsBean(CognitoIdentity)
+
+        and: 'ClientContext is not registered if Lambda Context::getClientContext is null"'
+        !handler.applicationContext.containsBean(ClientContext)
+
+        and:
+        "XXX" == response.body
+    }
+
+    static interface RequestIdProvider {
+        @NonNull
+        Optional<String> requestId();
+    }
+
+    @Requires(property = "spec.name", value = "LambdaContextSpec")
+    @Singleton
+    static class DefaultRequestIdProvider implements RequestIdProvider {
+        private final BeanProvider<Context> context
+
+        DefaultRequestIdProvider(@Any BeanProvider<Context> context) {
+            this.context = context
+        }
+
+        @Override
+        @NonNull
+        Optional<String> requestId() {
+            context.isPresent() ? Optional.of(context.get().awsRequestId) : Optional.empty()
+        }
+    }
+
+    @Requires(property = "spec.name", value = "LambdaContextSpec")
+    @Controller("/context")
+    static class LambdaContextSpecController {
+        @Inject
+        RequestIdProvider requestIdProvider
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get
+        String index() {
+            requestIdProvider.requestId().orElse("not found")
+        }
+    }
+
+    static Context createContextWithoutCollaborators() {
+        new Context() {
+            @Override
+            String getAwsRequestId() {
+                'XXX'
+            }
+
+            @Override
+            String getLogGroupName() {
+                null
+            }
+
+            @Override
+            String getLogStreamName() {
+                null
+            }
+
+            @Override
+            String getFunctionName() {
+                null
+            }
+
+            @Override
+            String getFunctionVersion() {
+                null
+            }
+
+            @Override
+            String getInvokedFunctionArn() {
+                null
+            }
+
+            @Override
+            CognitoIdentity getIdentity() {
+                null
+            }
+
+            @Override
+            ClientContext getClientContext() {
+                null
+            }
+
+            @Override
+            int getRemainingTimeInMillis() {
+                return 0
+            }
+
+            @Override
+            int getMemoryLimitInMB() {
+                return 0
+            }
+
+            @Override
+            LambdaLogger getLogger() {
+                null
+            }
+        }
+    }
+    static Context createContext() {
+        return new Context() {
+            @Override
+            String getAwsRequestId() {
+                return "XXX"
+            }
+
+            @Override
+            String getLogGroupName() {
+                null
+            }
+
+            @Override
+            String getLogStreamName() {
+                null
+            }
+
+            @Override
+            String getFunctionName() {
+                null
+            }
+
+            @Override
+            String getFunctionVersion() {
+                null
+            }
+
+            @Override
+            String getInvokedFunctionArn() {
+                null
+            }
+
+            @Override
+            CognitoIdentity getIdentity() {
+                new CognitoIdentity() {
+                    @Override
+                    String getIdentityId() {
+                        return "identityIDXXX"
+                    }
+
+                    @Override
+                    String getIdentityPoolId() {
+                        return "identityPoolIdXXX"
+                    }
+                }
+            }
+
+            @Override
+            ClientContext getClientContext() {
+                new ClientContext() {
+                    @Override
+                    Client getClient() {
+                        return new Client() {
+                            @Override
+                            String getInstallationId() {
+                                return "installationId"
+                            }
+
+                            @Override
+                            String getAppTitle() {
+                                null
+                            }
+
+                            @Override
+                            String getAppVersionName() {
+                                null
+                            }
+
+                            @Override
+                            String getAppVersionCode() {
+                                null
+                            }
+
+                            @Override
+                            String getAppPackageName() {
+                                null
+                            }
+                        }
+                    }
+
+                    @Override
+                    Map<String, String> getCustom() {
+                        null
+                    }
+
+                    @Override
+                    Map<String, String> getEnvironment() {
+                        null
+                    }
+                }
+            }
+
+            @Override
+            int getRemainingTimeInMillis() {
+                return 0
+            }
+
+            @Override
+            int getMemoryLimitInMB() {
+                return 0
+            }
+
+            @Override
+            LambdaLogger getLogger() {
+                return new LambdaLogger() {
+                    @Override
+                    void log(String message) {
+
+                    }
+
+                    @Override
+                    void log(byte[] message) {
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
@@ -24,12 +24,13 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextProvider;
+import io.micronaut.context.env.CommandLinePropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.TypeHint;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.cli.CommandLine;
@@ -39,7 +40,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.MicronautLambdaContext;
-import io.micronaut.function.aws.MicronautRequestHandler;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -48,7 +48,6 @@ import io.micronaut.http.MediaType;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.DefaultHttpClientConfiguration;
 import io.micronaut.http.client.HttpClient;
-import io.micronaut.context.env.CommandLinePropertySource;
 import io.micronaut.logging.LogLevel;
 
 import java.io.Closeable;
@@ -61,6 +60,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
 
+import static io.micronaut.function.aws.DiagnosticInfoPopulator.LAMBDA_TRACE_HEADER_PROP;
 import static io.micronaut.http.HttpHeaders.USER_AGENT;
 
 /**
@@ -402,7 +402,7 @@ public abstract class AbstractMicronautLambdaRuntime<RequestType, ResponseType, 
         String traceId = headers.get(LambdaRuntimeInvocationResponseHeaders.LAMBDA_RUNTIME_TRACE_ID);
         logn(LogLevel.DEBUG, "Trace id: ", traceId, '\n');
         if (StringUtils.isNotEmpty(traceId)) {
-            System.setProperty(MicronautRequestHandler.LAMBDA_TRACE_HEADER_PROP, traceId);
+            System.setProperty(LAMBDA_TRACE_HEADER_PROP, traceId);
         }
     }
 

--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
@@ -40,6 +40,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.MicronautLambdaContext;
+import io.micronaut.function.aws.XRayUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
@@ -59,8 +60,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
-
-import static io.micronaut.function.aws.DiagnosticInfoPopulator.LAMBDA_TRACE_HEADER_PROP;
 import static io.micronaut.http.HttpHeaders.USER_AGENT;
 
 /**
@@ -402,7 +401,7 @@ public abstract class AbstractMicronautLambdaRuntime<RequestType, ResponseType, 
         String traceId = headers.get(LambdaRuntimeInvocationResponseHeaders.LAMBDA_RUNTIME_TRACE_ID);
         logn(LogLevel.DEBUG, "Trace id: ", traceId, '\n');
         if (StringUtils.isNotEmpty(traceId)) {
-            System.setProperty(LAMBDA_TRACE_HEADER_PROP, traceId);
+            System.setProperty(XRayUtils.LAMBDA_TRACE_HEADER_PROP, traceId);
         }
     }
 

--- a/function-aws/src/main/java/io/micronaut/function/aws/DefaultDiagnosticInfoPopulator.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/DefaultDiagnosticInfoPopulator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+import org.slf4j.MDC;
+import com.amazonaws.services.lambda.runtime.Context;
+
+/**
+ * @author Sergio del Amo
+ * @author Constantine Linnick
+ * @since 3.2.2
+ */
+@Singleton
+public class DefaultDiagnosticInfoPopulator implements DiagnosticInfoPopulator {
+
+    public static final String MDC_DEFAULT_AWS_REQUEST_ID = "AWSRequestId";
+    public static final String MDC_DEFAULT_FUNCTION_NAME = "AWSFunctionName";
+    public static final String MDC_DEFAULT_FUNCTION_VERSION = "AWSFunctionVersion";
+    public static final String MDC_DEFAULT_FUNCTION_ARN = "AWSFunctionArn";
+    public static final String MDC_DEFAULT_FUNCTION_MEMORY_SIZE = "AWSFunctionMemoryLimit";
+    public static final String MDC_DEFAULT_FUNCTION_REMAINING_TIME = "AWSFunctionRemainingTime";
+    public static final String MDC_DEFAULT_XRAY_TRACE_ID = "AWS-XRAY-TRACE-ID";
+
+    /**
+     * @see <a href="https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html">AWS Lambda function logging in Java</a>
+     * @param context The Lambda execution environment context object.
+     */
+    @Override
+    public void populateMappingDiagnosticContextValues(@NonNull Context context) {
+        if (context.getAwsRequestId() != null) {
+            mdcput(MDC_DEFAULT_AWS_REQUEST_ID, context.getAwsRequestId());
+        }
+        if (context.getFunctionName() != null) {
+            mdcput(MDC_DEFAULT_FUNCTION_NAME, context.getFunctionName());
+        }
+        if (context.getFunctionVersion() != null) {
+            mdcput(MDC_DEFAULT_FUNCTION_VERSION, context.getFunctionVersion());
+        }
+        if (context.getInvokedFunctionArn() != null) {
+            mdcput(MDC_DEFAULT_FUNCTION_ARN, context.getInvokedFunctionArn());
+        }
+        mdcput(MDC_DEFAULT_FUNCTION_MEMORY_SIZE, String.valueOf(context.getMemoryLimitInMB()));
+        mdcput(MDC_DEFAULT_FUNCTION_REMAINING_TIME, String.valueOf(context.getRemainingTimeInMillis()));
+    }
+
+    /**
+     * Put a diagnostic context value.
+     * @param key non-null key
+     * @param val value to put in the map
+     * @throws IllegalArgumentException in case the "key" parameter is null
+     */
+    protected void mdcput(@NonNull String key, @NonNull String val) throws IllegalArgumentException {
+        MDC.put(key, val);
+    }
+
+    @Override
+    public void populateMappingDiagnosticContextWithXrayTraceId() {
+        XRayUtils.parseXrayTraceId().ifPresent(xrayTraceId -> mdcput(MDC_DEFAULT_XRAY_TRACE_ID, xrayTraceId));
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/DefaultLambdaContextFactory.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/DefaultLambdaContextFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import com.amazonaws.services.lambda.runtime.ClientContext;
+import com.amazonaws.services.lambda.runtime.CognitoIdentity;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.NonNull;
+import jakarta.inject.Singleton;
+
+/**
+ * Registers singletons of type {@link Context}.
+ * If the Lambda Context contains non-null {@link LambdaLogger}, {@link ClientContext} and {@link CognitoIdentity} they are registered as Singleton as well.
+ * @author Sergio del Amo
+ * @since 3.2.2
+ */
+@Singleton
+public class DefaultLambdaContextFactory implements LambdaContextFactory {
+
+    private final BeanContext beanContext;
+
+    /**
+     *
+     * @param beanContext Bean Context.
+     */
+    public DefaultLambdaContextFactory(BeanContext beanContext) {
+        this.beanContext = beanContext;
+    }
+
+    @Override
+    public void registerSingletons(@NonNull Context context) {
+        beanContext.registerSingleton(context);
+        LambdaLogger logger = context.getLogger();
+        if (logger != null) {
+            beanContext.registerSingleton(logger);
+        }
+        ClientContext clientContext = context.getClientContext();
+        if (clientContext != null) {
+            beanContext.registerSingleton(clientContext);
+        }
+        CognitoIdentity identity = context.getIdentity();
+        if (identity != null) {
+            beanContext.registerSingleton(identity);
+        }
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/DiagnosticInfoPopulator.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/DiagnosticInfoPopulator.java
@@ -1,0 +1,109 @@
+package io.micronaut.function.aws;
+
+import com.amazonaws.services.lambda.runtime.ClientContext;
+import com.amazonaws.services.lambda.runtime.CognitoIdentity;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.StringUtils;
+import org.slf4j.MDC;
+
+import java.util.Optional;
+
+@Introspected
+public class DiagnosticInfoPopulator {
+
+    public static final String ENV_X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
+
+    // See: https://github.com/aws/aws-xray-sdk-java/issues/251
+    public static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
+
+    public static final String MDC_DEFAULT_AWS_REQUEST_ID = "AWSRequestId";
+    public static final String MDC_DEFAULT_FUNCTION_NAME = "AWSFunctionName";
+    public static final String MDC_DEFAULT_FUNCTION_VERSION = "AWSFunctionVersion";
+    public static final String MDC_DEFAULT_FUNCTION_ARN = "AWSFunctionArn";
+    public static final String MDC_DEFAULT_FUNCTION_MEMORY_SIZE = "AWSFunctionMemoryLimit";
+    public static final String MDC_DEFAULT_FUNCTION_REMAINING_TIME = "AWSFunctionRemainingTime";
+    public static final String MDC_DEFAULT_XRAY_TRACE_ID = "AWS-XRAY-TRACE-ID";
+
+
+    /**
+     * Register the beans in the application.
+     *
+     * @param context context
+     * @param applicationContext application context
+     */
+    static void registerContextBeans(com.amazonaws.services.lambda.runtime.Context context, ApplicationContext applicationContext) {
+        applicationContext.registerSingleton(context);
+        LambdaLogger logger = context.getLogger();
+        if (logger != null) {
+            applicationContext.registerSingleton(logger);
+        }
+        ClientContext clientContext = context.getClientContext();
+        if (clientContext != null) {
+            applicationContext.registerSingleton(clientContext);
+        }
+        CognitoIdentity identity = context.getIdentity();
+        if (identity != null) {
+            applicationContext.registerSingleton(identity);
+        }
+    }
+
+    /**
+     * @see <a href="https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html">AWS Lambda function logging in Java</a>
+     * @param context The Lambda execution environment context object.
+     */
+    public void populateMappingDiagnosticContextValues(@NonNull com.amazonaws.services.lambda.runtime.Context context) {
+        if (context.getAwsRequestId() != null) {
+            mdcput(MDC_DEFAULT_AWS_REQUEST_ID, context.getAwsRequestId());
+        }
+        if (context.getFunctionName() != null) {
+            mdcput(MDC_DEFAULT_FUNCTION_NAME, context.getFunctionName());
+        }
+        if (context.getFunctionVersion() != null) {
+            mdcput(MDC_DEFAULT_FUNCTION_VERSION, context.getFunctionVersion());
+        }
+        if (context.getInvokedFunctionArn() != null) {
+            mdcput(MDC_DEFAULT_FUNCTION_ARN, context.getInvokedFunctionArn());
+        }
+        mdcput(MDC_DEFAULT_FUNCTION_MEMORY_SIZE, String.valueOf(context.getMemoryLimitInMB()));
+        mdcput(MDC_DEFAULT_FUNCTION_REMAINING_TIME, String.valueOf(context.getRemainingTimeInMillis()));
+    }
+
+    /**
+     * Put a diagnostic context value.
+     * @param key non-null key
+     * @param val value to put in the map
+     * @throws IllegalArgumentException in case the "key" parameter is null
+     */
+    protected void mdcput(@NonNull String key, @NonNull String val) throws IllegalArgumentException {
+        MDC.put(key, val);
+    }
+
+    /**
+     * Populate MDC with XRay Trace ID if is able to parse it.
+     */
+    public void populateMappingDiagnosticContextWithXrayTraceId() {
+        parseXrayTraceId().ifPresent(xrayTraceId -> mdcput(MDC_DEFAULT_XRAY_TRACE_ID, xrayTraceId));
+    }
+
+    /**
+     * Parses XRay Trace ID from _X_AMZN_TRACE_ID environment variable.
+     * @see <a href="https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html">Trace ID injection into logs</a>
+     * @return Trace id or empty if not found
+     */
+    @NonNull
+    protected static Optional<String> parseXrayTraceId() {
+        String lambdaTraceHeaderKey = System.getenv(ENV_X_AMZN_TRACE_ID);
+        lambdaTraceHeaderKey = StringUtils.isNotEmpty(lambdaTraceHeaderKey) ? lambdaTraceHeaderKey
+                : System.getProperty(LAMBDA_TRACE_HEADER_PROP);
+        if (lambdaTraceHeaderKey != null) {
+            String[] arr = lambdaTraceHeaderKey.split(";");
+            if (arr.length >= 1) {
+                return Optional.of(arr[0].replace("Root=", ""));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/DiagnosticInfoPopulator.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/DiagnosticInfoPopulator.java
@@ -26,6 +26,10 @@ import com.amazonaws.services.lambda.runtime.Context;
  */
 @DefaultImplementation(DefaultDiagnosticInfoPopulator.class)
 public interface DiagnosticInfoPopulator {
+    /**
+     * Populate MDC with Lambda Context values.
+     * @param context Lambda Context
+     */
     void populateMappingDiagnosticContextValues(@NonNull Context context);
 
     /**

--- a/function-aws/src/main/java/io/micronaut/function/aws/HandlerUtils.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/HandlerUtils.java
@@ -30,6 +30,13 @@ public final class HandlerUtils {
     private HandlerUtils() {
     }
 
+    /**
+     * It uses {@link LambdaContextFactory} to registers Lambda Context beans as singletons in the bean context.
+     * It uses {@link DiagnosticInfoPopulator} to populate the MDC context with Lambda Context values.
+     *
+     * @param applicationContextProvider Application Context Provider
+     * @param lambdaContext Lambda Context
+     */
     public static void configureWithContext(@NonNull ApplicationContextProvider applicationContextProvider,
                                             @Nullable Context lambdaContext) {
         ApplicationContext applicationContext = applicationContextProvider.getApplicationContext();

--- a/function-aws/src/main/java/io/micronaut/function/aws/HandlerUtils.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/HandlerUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextProvider;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Configures MDC and Bean Context with the current LambdaContext.
+ * @author Sergio del Amo
+ * @since 3.2.2
+ */
+public final class HandlerUtils {
+    private HandlerUtils() {
+    }
+
+    public static void configureWithContext(@NonNull ApplicationContextProvider applicationContextProvider,
+                                            @Nullable Context lambdaContext) {
+        ApplicationContext applicationContext = applicationContextProvider.getApplicationContext();
+        DiagnosticInfoPopulator mdcPopulator = null;
+        if (applicationContext.containsBean(DiagnosticInfoPopulator.class)) {
+            mdcPopulator = applicationContext.getBean(DiagnosticInfoPopulator.class);
+        }
+        if (lambdaContext != null) {
+            if (applicationContext.containsBean(LambdaContextFactory.class)) {
+                applicationContext.getBean(LambdaContextFactory.class)
+                        .registerSingletons(lambdaContext);
+            }
+            if (mdcPopulator != null) {
+                mdcPopulator.populateMappingDiagnosticContextValues(lambdaContext);
+            }
+        }
+        if (mdcPopulator != null) {
+            mdcPopulator.populateMappingDiagnosticContextWithXrayTraceId();
+        }
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/LambdaContextFactory.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/LambdaContextFactory.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 package io.micronaut.function.aws;
-
+import com.amazonaws.services.lambda.runtime.Context;
 import io.micronaut.context.annotation.DefaultImplementation;
 import io.micronaut.core.annotation.NonNull;
-import com.amazonaws.services.lambda.runtime.Context;
 
 /**
- * Populates Mapping Diagnostic Context with Lambda Context.
+ * Register Lambda Context singletons for the current Handler execution.
  * @author Sergio del Amo
- * @since 3.2.0
+ * @since 3.2.2
  */
-@DefaultImplementation(DefaultDiagnosticInfoPopulator.class)
-public interface DiagnosticInfoPopulator {
-    void populateMappingDiagnosticContextValues(@NonNull Context context);
-
+@DefaultImplementation(DefaultLambdaContextFactory.class)
+@FunctionalInterface
+public interface LambdaContextFactory {
     /**
-     * Populate MDC with XRay Trace ID if it is able to parse it.
+     * Registers Lambda Context as a singleton.
+     * @param lambdaContext Lambda Context
      */
-    void populateMappingDiagnosticContextWithXrayTraceId();
+    void registerSingletons(@NonNull Context lambdaContext);
 }

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -15,21 +15,18 @@
  */
 package io.micronaut.function.aws;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.*;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionError;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.function.executor.AbstractFunctionExecutor;
-
+import org.slf4j.MDC;
 import java.util.Optional;
-
-import static io.micronaut.function.aws.DiagnosticInfoPopulator.registerContextBeans;
 
 /**
  * <p>An Amazon Lambda {@link RequestHandler} implementation for Micronaut {@link io.micronaut.function.FunctionBean}</p>.
@@ -41,9 +38,55 @@ import static io.micronaut.function.aws.DiagnosticInfoPopulator.registerContextB
  */
 public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExecutor<I, O, Context> implements RequestHandler<I, O>, MicronautLambdaContext {
 
+    public static final String ENV_X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
+
+    // See: https://github.com/aws/aws-xray-sdk-java/issues/251
+    public static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_AWS_REQUEST_ID = "AWSRequestId";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_FUNCTION_NAME = "AWSFunctionName";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_FUNCTION_VERSION = "AWSFunctionVersion";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_FUNCTION_ARN = "AWSFunctionArn";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_FUNCTION_MEMORY_SIZE = "AWSFunctionMemoryLimit";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_FUNCTION_REMAINING_TIME = "AWSFunctionRemainingTime";
+
+    /**
+     * @deprecated Use the bena of type {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    public static final String MDC_DEFAULT_XRAY_TRACE_ID = "AWS-XRAY-TRACE-ID";
+
     @SuppressWarnings("unchecked")
     private final Class<I> inputType = initTypeArgument();
-    protected final DiagnosticInfoPopulator diagnosticInfoPopulator;
 
     /**
      * Default constructor; will initialize a suitable {@link ApplicationContext} for
@@ -52,7 +95,6 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     public MicronautRequestHandler() {
         buildApplicationContext(null);
         injectIntoApplicationContext();
-        this.diagnosticInfoPopulator = applicationContext.getBean(DiagnosticInfoPopulator.class);
     }
 
     /**
@@ -61,28 +103,71 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
      */
     public MicronautRequestHandler(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+        startEnvironment(applicationContext);
         injectIntoApplicationContext();
-        this.diagnosticInfoPopulator = applicationContext.getBean(DiagnosticInfoPopulator.class);
+    }
+
+    /**
+     * Constructor used to inject a preexisting {@link ApplicationContextBuilder}.
+     * @param applicationContextBuilder the application context builder
+     */
+    public MicronautRequestHandler(ApplicationContextBuilder applicationContextBuilder) {
+        this(applicationContextBuilder.build());
     }
 
     private void injectIntoApplicationContext() {
         applicationContext.inject(this);
-        applicationContext.inject(new DiagnosticInfoPopulator());
     }
 
     @Override
     public final O handleRequest(I input, Context context) {
-        if (context != null) {
-            registerContextBeans(context, applicationContext);
-            diagnosticInfoPopulator.populateMappingDiagnosticContextValues(context);
-        }
-        diagnosticInfoPopulator.populateMappingDiagnosticContextWithXrayTraceId();
+        HandlerUtils.configureWithContext(this, context);
         if (!inputType.isInstance(input)) {
             input = convertInput(input);
         }
         return this.execute(input);
     }
 
+    /**
+     * @see <a href="https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html">AWS Lambda function logging in Java</a>
+     * @param context The Lambda execution environment context object.
+     * @deprecated Use {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    protected void populateMappingDiagnosticContextValues(@NonNull Context context) {
+    }
+
+    /**
+     * Put a diagnostic context value.
+     * @param key non-null key
+     * @param val value to put in the map
+     * @throws IllegalArgumentException in case the "key" parameter is null
+     * @deprecated Use {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    protected void mdcput(@NonNull String key, @NonNull String val) throws IllegalArgumentException {
+        MDC.put(key, val);
+    }
+
+    /**
+     * Populate MDC with XRay Trace ID if is able to parse it.
+     * @deprecated Use {@link DiagnosticInfoPopulator} instead.
+     */
+    @Deprecated
+    protected void populateMappingDiagnosticContextWithXrayTraceId() {
+    }
+
+    /**
+     * Parses XRay Trace ID from _X_AMZN_TRACE_ID environment variable.
+     * @see <a href="https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html">Trace ID injection into logs</a>
+     * @return Trace id or empty if not found
+     * @deprecated Use {@link XRayUtils#parseXrayTraceId()} instead.
+     */
+    @NonNull
+    @Deprecated
+    protected static Optional<String> parseXrayTraceId() {
+       return XRayUtils.parseXrayTraceId();
+    }
 
     /**
      * Converts the input the required type. Subclasses can override to provide custom conversion.
@@ -114,6 +199,18 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     @NonNull
     protected ApplicationContextBuilder newApplicationContextBuilder() {
         return new LambdaApplicationContextBuilder();
+    }
+
+    /**
+     * Register the beans in the application.
+     *
+     * @param context context
+     * @param applicationContext application context
+     * @deprecated Use the bena of type {@link LambdaContextFactory} instead.
+     */
+    @Deprecated
+    static void registerContextBeans(Context context, ApplicationContext applicationContext) {
+        applicationContext.getBean(LambdaContextFactory.class).registerSingletons(context);
     }
 
     private Class initTypeArgument() {

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -15,19 +15,21 @@
  */
 package io.micronaut.function.aws;
 
-import com.amazonaws.services.lambda.runtime.*;
-import io.micronaut.core.annotation.NonNull;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionContext;
 import io.micronaut.core.convert.ConversionError;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.util.ArrayUtils;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.executor.AbstractFunctionExecutor;
-import org.slf4j.MDC;
+
 import java.util.Optional;
+
+import static io.micronaut.function.aws.DiagnosticInfoPopulator.registerContextBeans;
 
 /**
  * <p>An Amazon Lambda {@link RequestHandler} implementation for Micronaut {@link io.micronaut.function.FunctionBean}</p>.
@@ -39,21 +41,9 @@ import java.util.Optional;
  */
 public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExecutor<I, O, Context> implements RequestHandler<I, O>, MicronautLambdaContext {
 
-    public static final String ENV_X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
-
-    // See: https://github.com/aws/aws-xray-sdk-java/issues/251
-    public static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
-
-    public static final String MDC_DEFAULT_AWS_REQUEST_ID = "AWSRequestId";
-    public static final String MDC_DEFAULT_FUNCTION_NAME = "AWSFunctionName";
-    public static final String MDC_DEFAULT_FUNCTION_VERSION = "AWSFunctionVersion";
-    public static final String MDC_DEFAULT_FUNCTION_ARN = "AWSFunctionArn";
-    public static final String MDC_DEFAULT_FUNCTION_MEMORY_SIZE = "AWSFunctionMemoryLimit";
-    public static final String MDC_DEFAULT_FUNCTION_REMAINING_TIME = "AWSFunctionRemainingTime";
-    public static final String MDC_DEFAULT_XRAY_TRACE_ID = "AWS-XRAY-TRACE-ID";
-
     @SuppressWarnings("unchecked")
     private final Class<I> inputType = initTypeArgument();
+    protected final DiagnosticInfoPopulator diagnosticInfoPopulator;
 
     /**
      * Default constructor; will initialize a suitable {@link ApplicationContext} for
@@ -62,6 +52,7 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     public MicronautRequestHandler() {
         buildApplicationContext(null);
         injectIntoApplicationContext();
+        this.diagnosticInfoPopulator = applicationContext.getBean(DiagnosticInfoPopulator.class);
     }
 
     /**
@@ -71,81 +62,27 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     public MicronautRequestHandler(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
         injectIntoApplicationContext();
+        this.diagnosticInfoPopulator = applicationContext.getBean(DiagnosticInfoPopulator.class);
     }
 
     private void injectIntoApplicationContext() {
         applicationContext.inject(this);
+        applicationContext.inject(new DiagnosticInfoPopulator());
     }
 
     @Override
     public final O handleRequest(I input, Context context) {
         if (context != null) {
             registerContextBeans(context, applicationContext);
-            populateMappingDiagnosticContextValues(context);
+            diagnosticInfoPopulator.populateMappingDiagnosticContextValues(context);
         }
-        populateMappingDiagnosticContextWithXrayTraceId();
+        diagnosticInfoPopulator.populateMappingDiagnosticContextWithXrayTraceId();
         if (!inputType.isInstance(input)) {
             input = convertInput(input);
         }
         return this.execute(input);
     }
 
-    /**
-     * @see <a href="https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html">AWS Lambda function logging in Java</a>
-     * @param context The Lambda execution environment context object.
-     */
-    protected void populateMappingDiagnosticContextValues(@NonNull Context context) {
-        if (context.getAwsRequestId() != null) {
-            mdcput(MDC_DEFAULT_AWS_REQUEST_ID, context.getAwsRequestId());
-        }
-        if (context.getFunctionName() != null) {
-            mdcput(MDC_DEFAULT_FUNCTION_NAME, context.getFunctionName());
-        }
-        if (context.getFunctionVersion() != null) {
-            mdcput(MDC_DEFAULT_FUNCTION_VERSION, context.getFunctionVersion());
-        }
-        if (context.getInvokedFunctionArn() != null) {
-            mdcput(MDC_DEFAULT_FUNCTION_ARN, context.getInvokedFunctionArn());
-        }
-        mdcput(MDC_DEFAULT_FUNCTION_MEMORY_SIZE, String.valueOf(context.getMemoryLimitInMB()));
-        mdcput(MDC_DEFAULT_FUNCTION_REMAINING_TIME, String.valueOf(context.getRemainingTimeInMillis()));
-    }
-
-    /**
-     * Put a diagnostic context value.
-     * @param key non-null key
-     * @param val value to put in the map
-     * @throws IllegalArgumentException in case the "key" parameter is null
-     */
-    protected void mdcput(@NonNull String key, @NonNull String val) throws IllegalArgumentException {
-        MDC.put(key, val);
-    }
-
-    /**
-     * Populate MDC with XRay Trace ID if is able to parse it.
-     */
-    protected void populateMappingDiagnosticContextWithXrayTraceId() {
-        parseXrayTraceId().ifPresent(xrayTraceId -> mdcput(MDC_DEFAULT_XRAY_TRACE_ID, xrayTraceId));
-    }
-
-    /**
-     * Parses XRay Trace ID from _X_AMZN_TRACE_ID environment variable.
-     * @see <a href="https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html">Trace ID injection into logs</a>
-     * @return Trace id or empty if not found
-     */
-    @NonNull
-    protected static Optional<String> parseXrayTraceId() {
-        String lambdaTraceHeaderKey = System.getenv(ENV_X_AMZN_TRACE_ID);
-        lambdaTraceHeaderKey = StringUtils.isNotEmpty(lambdaTraceHeaderKey) ? lambdaTraceHeaderKey
-                : System.getProperty(LAMBDA_TRACE_HEADER_PROP);
-        if (lambdaTraceHeaderKey != null) {
-            String[] arr = lambdaTraceHeaderKey.split(";");
-            if (arr.length >= 1) {
-                return Optional.of(arr[0].replace("Root=", ""));
-            }
-        }
-        return Optional.empty();
-    }
 
     /**
      * Converts the input the required type. Subclasses can override to provide custom conversion.
@@ -177,28 +114,6 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
     @NonNull
     protected ApplicationContextBuilder newApplicationContextBuilder() {
         return new LambdaApplicationContextBuilder();
-    }
-
-    /**
-     * Register the beans in the application.
-     *
-     * @param context context
-     * @param applicationContext application context
-     */
-    static void registerContextBeans(Context context, ApplicationContext applicationContext) {
-        applicationContext.registerSingleton(context);
-        LambdaLogger logger = context.getLogger();
-        if (logger != null) {
-            applicationContext.registerSingleton(logger);
-        }
-        ClientContext clientContext = context.getClientContext();
-        if (clientContext != null) {
-            applicationContext.registerSingleton(clientContext);
-        }
-        CognitoIdentity identity = context.getIdentity();
-        if (identity != null) {
-            applicationContext.registerSingleton(identity);
-        }
     }
 
     private Class initTypeArgument() {

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static io.micronaut.function.aws.MicronautRequestHandler.registerContextBeans;
+import static io.micronaut.function.aws.DiagnosticInfoPopulator.registerContextBeans;
 
 /**
  * <p>An implementation of the {@link RequestStreamHandler} for Micronaut</p>.

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -27,8 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static io.micronaut.function.aws.DiagnosticInfoPopulator.registerContextBeans;
-
 /**
  * <p>An implementation of the {@link RequestStreamHandler} for Micronaut</p>.
  *
@@ -59,19 +57,21 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
         this.applicationContext = applicationContext;
     }
 
-    @Override
-    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
-        execute(input, output, context);
+    /**
+     * Constructor used to inject a preexisting {@link ApplicationContextBuilder}.
+     * @param applicationContextBuilder the application context builder
+     */
+    public MicronautRequestStreamHandler(ApplicationContextBuilder applicationContextBuilder) {
+        this(applicationContextBuilder.build());
     }
 
     @Override
-    protected ApplicationContext buildApplicationContext(Context context) {
-        ApplicationContext applicationContext = super.buildApplicationContext(context);
+    public void handleRequest(InputStream input, OutputStream output, Context context) throws IOException {
+        HandlerUtils.configureWithContext(this, context);
         if (context != null) {
-            registerContextBeans(context, applicationContext);
             this.ctxFunctionName = context.getFunctionName();
         }
-        return applicationContext;
+        execute(input, output, context);
     }
 
     @NonNull

--- a/function-aws/src/main/java/io/micronaut/function/aws/XRayUtils.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/XRayUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.Optional;
+
+/**
+ * Utility class to parse X-Ray Trace ID.
+ * @author Sergio del Amo
+ * @since 3.2.2
+ */
+public final class XRayUtils {
+    private static final String ENV_X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
+
+    /**
+     * <a href="https://github.com/aws/aws-xray-sdk-java/issues/251">Read _X_AMZN_TRACE_ID from system properties if environment variable is not set</a>.
+     */
+    public static final String LAMBDA_TRACE_HEADER_PROP = "com.amazonaws.xray.traceHeader";
+
+    /**
+     * Constructor.
+     */
+    private XRayUtils() {
+    }
+
+    /**
+     * Parses XRay Trace ID from _X_AMZN_TRACE_ID environment variable.
+     * @see <a href="https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html">Trace ID injection into logs</a>
+     * @return Trace id or empty if not found
+     */
+    @NonNull
+    public static Optional<String> parseXrayTraceId() {
+        String lambdaTraceHeaderKey = System.getenv(ENV_X_AMZN_TRACE_ID);
+        lambdaTraceHeaderKey = StringUtils.isNotEmpty(lambdaTraceHeaderKey) ? lambdaTraceHeaderKey
+                : System.getProperty(LAMBDA_TRACE_HEADER_PROP);
+        if (lambdaTraceHeaderKey != null) {
+            String[] arr = lambdaTraceHeaderKey.split(";");
+            if (arr.length >= 1) {
+                return Optional.of(arr[0].replace("Root=", ""));
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/LambdaContextSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/LambdaContextSpec.groovy
@@ -1,0 +1,271 @@
+package io.micronaut.function.aws
+
+import com.amazonaws.services.lambda.runtime.*
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.BeanProvider
+import io.micronaut.context.annotation.Any
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class LambdaContextSpec extends Specification {
+
+    void "Lambda Context beans are registered"() {
+        given:
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+                .properties(Collections.singletonMap(
+                        "spec.name", "LambdaContextSpec"
+                ))
+        MicronautRequestHandler handler = new LambdaContextSpecHandler(builder)
+
+        when:
+        String result = handler.handleRequest("Foo", createContext())
+
+        then:
+        handler.applicationContext.containsBean(Context)
+        handler.applicationContext.containsBean(LambdaLogger)
+        handler.applicationContext.containsBean(CognitoIdentity)
+        handler.applicationContext.containsBean(ClientContext)
+        "XXX" == result
+    }
+
+    void "verify LambdaLogger CognitoIdentity and ClientContext are not registered if null"() {
+        given:
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+                .properties(Collections.singletonMap(
+                        "spec.name", "LambdaContextSpec"
+                ))
+        MicronautRequestHandler handler = new LambdaContextSpecHandler(builder)
+
+        when:
+        String result = handler.handleRequest("Foo", createContextWithoutCollaborators())
+
+        then:
+        handler.applicationContext.containsBean(Context)
+        and: 'LambdaLogger is not registered if Lambda Context::getLambdaLogger is null'
+        !handler.applicationContext.containsBean(LambdaLogger)
+
+        and: 'CognitoIdentity is not registered if Lambda Context::getIdentity is null"'
+        !handler.applicationContext.containsBean(CognitoIdentity)
+
+        and: 'ClientContext is not registered if Lambda Context::getClientContext is null"'
+        !handler.applicationContext.containsBean(ClientContext)
+
+        and:
+        "XXX" == result
+    }
+
+    static interface RequestIdProvider {
+        @NonNull
+        Optional<String> requestId();
+    }
+
+    @Requires(property = "spec.name", value = "LambdaContextSpec")
+    @Singleton
+    static class DefaultRequestIdProvider implements RequestIdProvider {
+        private final BeanProvider<Context> context
+
+        DefaultRequestIdProvider(@Any BeanProvider<Context> context) {
+            this.context = context
+        }
+
+        @Override
+        @NonNull
+        Optional<String> requestId() {
+            context.isPresent() ? Optional.of(context.get().awsRequestId) : Optional.empty()
+        }
+    }
+
+    static class LambdaContextSpecHandler extends MicronautRequestHandler<String, String> {
+        @Inject
+        RequestIdProvider requestIdProvider
+        LambdaContextSpecHandler(ApplicationContextBuilder builder) {
+            super(builder)
+        }
+
+        @Override
+        String execute(String input) {
+            requestIdProvider.requestId().orElse(null)
+        }
+    }
+
+    static Context createContextWithoutCollaborators() {
+        new Context() {
+            @Override
+            String getAwsRequestId() {
+                'XXX'
+            }
+
+            @Override
+            String getLogGroupName() {
+                null
+            }
+
+            @Override
+            String getLogStreamName() {
+                null
+            }
+
+            @Override
+            String getFunctionName() {
+                null
+            }
+
+            @Override
+            String getFunctionVersion() {
+                null
+            }
+
+            @Override
+            String getInvokedFunctionArn() {
+                null
+            }
+
+            @Override
+            CognitoIdentity getIdentity() {
+                null
+            }
+
+            @Override
+            ClientContext getClientContext() {
+                null
+            }
+
+            @Override
+            int getRemainingTimeInMillis() {
+                return 0
+            }
+
+            @Override
+            int getMemoryLimitInMB() {
+                return 0
+            }
+
+            @Override
+            LambdaLogger getLogger() {
+                null
+            }
+        }
+    }
+    static Context createContext() {
+        return new Context() {
+            @Override
+            String getAwsRequestId() {
+                return "XXX"
+            }
+
+            @Override
+            String getLogGroupName() {
+                null
+            }
+
+            @Override
+            String getLogStreamName() {
+                null
+            }
+
+            @Override
+            String getFunctionName() {
+                null
+            }
+
+            @Override
+            String getFunctionVersion() {
+                null
+            }
+
+            @Override
+            String getInvokedFunctionArn() {
+                null
+            }
+
+            @Override
+            CognitoIdentity getIdentity() {
+                new CognitoIdentity() {
+                    @Override
+                    String getIdentityId() {
+                        return "identityIDXXX"
+                    }
+
+                    @Override
+                    String getIdentityPoolId() {
+                        return "identityPoolIdXXX"
+                    }
+                }
+            }
+
+            @Override
+            ClientContext getClientContext() {
+                new ClientContext() {
+                    @Override
+                    Client getClient() {
+                        return new Client() {
+                            @Override
+                            String getInstallationId() {
+                                return "installationId"
+                            }
+
+                            @Override
+                            String getAppTitle() {
+                                null
+                            }
+
+                            @Override
+                            String getAppVersionName() {
+                                null
+                            }
+
+                            @Override
+                            String getAppVersionCode() {
+                                null
+                            }
+
+                            @Override
+                            String getAppPackageName() {
+                                null
+                            }
+                        }
+                    }
+
+                    @Override
+                    Map<String, String> getCustom() {
+                        null
+                    }
+
+                    @Override
+                    Map<String, String> getEnvironment() {
+                        null
+                    }
+                }
+            }
+
+            @Override
+            int getRemainingTimeInMillis() {
+                return 0
+            }
+
+            @Override
+            int getMemoryLimitInMB() {
+                return 0
+            }
+
+            @Override
+            LambdaLogger getLogger() {
+                return new LambdaLogger() {
+                    @Override
+                    void log(String message) {
+
+                    }
+
+                    @Override
+                    void log(byte[] message) {
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/LambdaContextSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/LambdaContextSpec.groovy
@@ -66,6 +66,7 @@ class LambdaContextSpec extends Specification {
     @Requires(property = "spec.name", value = "LambdaContextSpec")
     @Singleton
     static class DefaultRequestIdProvider implements RequestIdProvider {
+
         private final BeanProvider<Context> context
 
         DefaultRequestIdProvider(@Any BeanProvider<Context> context) {
@@ -92,180 +93,23 @@ class LambdaContextSpec extends Specification {
         }
     }
 
-    static Context createContextWithoutCollaborators() {
-        new Context() {
-            @Override
-            String getAwsRequestId() {
-                'XXX'
-            }
-
-            @Override
-            String getLogGroupName() {
-                null
-            }
-
-            @Override
-            String getLogStreamName() {
-                null
-            }
-
-            @Override
-            String getFunctionName() {
-                null
-            }
-
-            @Override
-            String getFunctionVersion() {
-                null
-            }
-
-            @Override
-            String getInvokedFunctionArn() {
-                null
-            }
-
-            @Override
-            CognitoIdentity getIdentity() {
-                null
-            }
-
-            @Override
-            ClientContext getClientContext() {
-                null
-            }
-
-            @Override
-            int getRemainingTimeInMillis() {
-                return 0
-            }
-
-            @Override
-            int getMemoryLimitInMB() {
-                return 0
-            }
-
-            @Override
-            LambdaLogger getLogger() {
-                null
-            }
+    Context createContextWithoutCollaborators() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> null
+            getClientContext() >> null
+            getClientContext() >> null
+            getLogger() >> null
         }
     }
-    static Context createContext() {
-        return new Context() {
-            @Override
-            String getAwsRequestId() {
-                return "XXX"
-            }
 
-            @Override
-            String getLogGroupName() {
-                null
-            }
-
-            @Override
-            String getLogStreamName() {
-                null
-            }
-
-            @Override
-            String getFunctionName() {
-                null
-            }
-
-            @Override
-            String getFunctionVersion() {
-                null
-            }
-
-            @Override
-            String getInvokedFunctionArn() {
-                null
-            }
-
-            @Override
-            CognitoIdentity getIdentity() {
-                new CognitoIdentity() {
-                    @Override
-                    String getIdentityId() {
-                        return "identityIDXXX"
-                    }
-
-                    @Override
-                    String getIdentityPoolId() {
-                        return "identityPoolIdXXX"
-                    }
-                }
-            }
-
-            @Override
-            ClientContext getClientContext() {
-                new ClientContext() {
-                    @Override
-                    Client getClient() {
-                        return new Client() {
-                            @Override
-                            String getInstallationId() {
-                                return "installationId"
-                            }
-
-                            @Override
-                            String getAppTitle() {
-                                null
-                            }
-
-                            @Override
-                            String getAppVersionName() {
-                                null
-                            }
-
-                            @Override
-                            String getAppVersionCode() {
-                                null
-                            }
-
-                            @Override
-                            String getAppPackageName() {
-                                null
-                            }
-                        }
-                    }
-
-                    @Override
-                    Map<String, String> getCustom() {
-                        null
-                    }
-
-                    @Override
-                    Map<String, String> getEnvironment() {
-                        null
-                    }
-                }
-            }
-
-            @Override
-            int getRemainingTimeInMillis() {
-                return 0
-            }
-
-            @Override
-            int getMemoryLimitInMB() {
-                return 0
-            }
-
-            @Override
-            LambdaLogger getLogger() {
-                return new LambdaLogger() {
-                    @Override
-                    void log(String message) {
-
-                    }
-
-                    @Override
-                    void log(byte[] message) {
-
-                    }
-                }
-            }
+    Context createContext() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> Mock(CognitoIdentity)
+            getClientContext() >> Mock(ClientContext)
+            getClientContext() >> Mock(ClientContext)
+            getLogger() >> Mock(LambdaLogger)
         }
     }
 }

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MappingDiagnosticContextSetterSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MappingDiagnosticContextSetterSpec.groovy
@@ -1,27 +1,27 @@
 package io.micronaut.function.aws
 
 import com.amazonaws.services.lambda.runtime.Context
-import io.micronaut.core.annotation.NonNull
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import io.micronaut.core.annotation.NonNull
+import jakarta.inject.Singleton
 import spock.lang.Specification
 
 class MappingDiagnosticContextSetterSpec extends Specification {
-    static class CustomSquareHandler extends SquareHandler {
-        Map<String, Object> values = [:]
-       
-        @Override
-        protected void mdcput(@NonNull String key, @NonNull String value) {
-            values.put(key, value)
-        }
-    }
 
     void "context cannot be null"() {
         given:
-        MicronautRequestHandler handler = new CustomSquareHandler()
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+                .properties(Collections.singletonMap(
+                        "spec.name", "MappingDiagnosticContextSetterSpec"
+                ))
+        MicronautRequestHandler handler = new SquareHandler(builder)
         String awsRequestId = '6bc28136-xmpl-4365-b021-0ce6b2e64ab0'
 
         when:
-        def stubContext = Stub(Context){
+        def stubContext = Stub(Context) {
             getAwsRequestId() >> awsRequestId
         }
         Integer input = 12
@@ -30,7 +30,29 @@ class MappingDiagnosticContextSetterSpec extends Specification {
         then:
         noExceptionThrown()
 
-        handler.values['AWSRequestId'] == awsRequestId
+        handler.applicationContext.getBean(DiagnosticInfoPopulatorReplacement).values['AWSRequestId'] == awsRequestId
+    }
+
+    @Requires(property = "spec.name", value = "MappingDiagnosticContextSetterSpec")
+    @Replaces(DiagnosticInfoPopulator)
+    @Singleton
+    static class DiagnosticInfoPopulatorReplacement extends DefaultDiagnosticInfoPopulator {
+        Map<String, Object> values = [:]
+
+        @Override
+        protected void mdcput(@NonNull String key, @NonNull String value) {
+            values.put(key, value)
+        }
+    }
+
+    @Requires(property = "spec.name", value = "MappingDiagnosticContextSetterSpec")
+    @Singleton
+    @Replaces(SquareService)
+    static class MockSquareService implements SquareService {
+        @Override
+        int square(int input) {
+            return input * input;
+        }
     }
 
 }

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestStreamHandlerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestStreamHandlerSpec.groovy
@@ -38,7 +38,6 @@ class MicronautRequestStreamHandlerSpec extends Specification{
             }
         }
 
-
         when:
         def body = '{"title":"The Stand"}'
         def input = new ByteArrayInputStream()

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautStreamHandlerLambdaContextSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautStreamHandlerLambdaContextSpec.groovy
@@ -126,180 +126,23 @@ class MicronautStreamHandlerLambdaContextSpec extends Specification {
         }
     }
 
-    static Context createContextWithoutCollaborators() {
-        new Context() {
-            @Override
-            String getAwsRequestId() {
-                'XXX'
-            }
-
-            @Override
-            String getLogGroupName() {
-                null
-            }
-
-            @Override
-            String getLogStreamName() {
-                null
-            }
-
-            @Override
-            String getFunctionName() {
-                null
-            }
-
-            @Override
-            String getFunctionVersion() {
-                null
-            }
-
-            @Override
-            String getInvokedFunctionArn() {
-                null
-            }
-
-            @Override
-            CognitoIdentity getIdentity() {
-                null
-            }
-
-            @Override
-            ClientContext getClientContext() {
-                null
-            }
-
-            @Override
-            int getRemainingTimeInMillis() {
-                return 0
-            }
-
-            @Override
-            int getMemoryLimitInMB() {
-                return 0
-            }
-
-            @Override
-            LambdaLogger getLogger() {
-                null
-            }
+    Context createContextWithoutCollaborators() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> null
+            getClientContext() >> null
+            getClientContext() >> null
+            getLogger() >> null
         }
     }
-    static Context createContext() {
-        return new Context() {
-            @Override
-            String getAwsRequestId() {
-                return "XXX"
-            }
 
-            @Override
-            String getLogGroupName() {
-                null
-            }
-
-            @Override
-            String getLogStreamName() {
-                null
-            }
-
-            @Override
-            String getFunctionName() {
-                null
-            }
-
-            @Override
-            String getFunctionVersion() {
-                null
-            }
-
-            @Override
-            String getInvokedFunctionArn() {
-                null
-            }
-
-            @Override
-            CognitoIdentity getIdentity() {
-                new CognitoIdentity() {
-                    @Override
-                    String getIdentityId() {
-                        return "identityIDXXX"
-                    }
-
-                    @Override
-                    String getIdentityPoolId() {
-                        return "identityPoolIdXXX"
-                    }
-                }
-            }
-
-            @Override
-            ClientContext getClientContext() {
-                new ClientContext() {
-                    @Override
-                    Client getClient() {
-                        return new Client() {
-                            @Override
-                            String getInstallationId() {
-                                return "installationId"
-                            }
-
-                            @Override
-                            String getAppTitle() {
-                                null
-                            }
-
-                            @Override
-                            String getAppVersionName() {
-                                null
-                            }
-
-                            @Override
-                            String getAppVersionCode() {
-                                null
-                            }
-
-                            @Override
-                            String getAppPackageName() {
-                                null
-                            }
-                        }
-                    }
-
-                    @Override
-                    Map<String, String> getCustom() {
-                        null
-                    }
-
-                    @Override
-                    Map<String, String> getEnvironment() {
-                        null
-                    }
-                }
-            }
-
-            @Override
-            int getRemainingTimeInMillis() {
-                return 0
-            }
-
-            @Override
-            int getMemoryLimitInMB() {
-                return 0
-            }
-
-            @Override
-            LambdaLogger getLogger() {
-                return new LambdaLogger() {
-                    @Override
-                    void log(String message) {
-
-                    }
-
-                    @Override
-                    void log(byte[] message) {
-
-                    }
-                }
-            }
+    Context createContext() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> Mock(CognitoIdentity)
+            getClientContext() >> Mock(ClientContext)
+            getClientContext() >> Mock(ClientContext)
+            getLogger() >> Mock(LambdaLogger)
         }
     }
 }

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautStreamHandlerLambdaContextSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautStreamHandlerLambdaContextSpec.groovy
@@ -1,0 +1,305 @@
+package io.micronaut.function.aws
+
+import com.amazonaws.services.lambda.runtime.*
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextBuilder
+import io.micronaut.context.BeanProvider
+import io.micronaut.context.annotation.Any
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.Environment
+import io.micronaut.core.annotation.NonNull
+import io.micronaut.core.util.StringUtils
+import io.micronaut.function.FunctionBean
+import jakarta.inject.Inject
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+import java.util.function.Function
+
+class MicronautStreamHandlerLambdaContextSpec extends Specification {
+
+    void "Lambda Context beans are registered"() {
+        given:
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+                .properties(Collections.singletonMap(
+                        "spec.name", "MicronautStreamHandlerLambdaContextSpec"
+                ))
+        MicronautRequestStreamHandler handler = new LambdaContextSpecHandler(builder)
+        handler.applicationContext.start()
+
+        when:
+        ByteArrayInputStream input = new ByteArrayInputStream("Foo".bytes)
+        ByteArrayOutputStream output = new ByteArrayOutputStream()
+        handler.handleRequest(input, output, createContext())
+        String result = output.toString()
+
+        then:
+        handler.applicationContext.containsBean(Context)
+        handler.applicationContext.containsBean(LambdaLogger)
+        handler.applicationContext.containsBean(CognitoIdentity)
+        handler.applicationContext.containsBean(ClientContext)
+        "XXX" == result
+
+        cleanup:
+        handler.applicationContext.close()
+    }
+
+    void "verify LambdaLogger CognitoIdentity and ClientContext are not registered if null"() {
+        given:
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+                .properties(Collections.singletonMap(
+                        "spec.name", "MicronautStreamHandlerLambdaContextSpec"
+                ))
+        MicronautRequestStreamHandler handler = new LambdaContextSpecHandler(builder)
+        handler.applicationContext.start()
+
+        when:
+        ByteArrayInputStream input = new ByteArrayInputStream("Foo".bytes)
+        ByteArrayOutputStream output = new ByteArrayOutputStream()
+        handler.handleRequest(input, output, createContextWithoutCollaborators())
+        String result = output.toString()
+
+        then:
+        handler.applicationContext.containsBean(Context)
+        and: 'LambdaLogger is not registered if Lambda Context::getLambdaLogger is null'
+        !handler.applicationContext.containsBean(LambdaLogger)
+
+        and: 'CognitoIdentity is not registered if Lambda Context::getIdentity is null"'
+        !handler.applicationContext.containsBean(CognitoIdentity)
+
+        and: 'ClientContext is not registered if Lambda Context::getClientContext is null"'
+        !handler.applicationContext.containsBean(ClientContext)
+
+        and:
+        "XXX" == result
+
+        cleanup:
+        handler.applicationContext.close()
+    }
+
+    static interface RequestIdProvider {
+        @NonNull
+        Optional<String> requestId();
+    }
+
+    @Requires(property = "spec.name", value = "MicronautStreamHandlerLambdaContextSpec")
+    @Singleton
+    static class DefaultRequestIdProvider implements RequestIdProvider {
+        private final BeanProvider<Context> context
+
+        DefaultRequestIdProvider(@Any BeanProvider<Context> context) {
+            this.context = context
+        }
+
+        @Override
+        @NonNull
+        Optional<String> requestId() {
+            context.isPresent() ? Optional.of(context.get().awsRequestId) : Optional.empty()
+        }
+    }
+
+    static class LambdaContextSpecHandler extends MicronautRequestStreamHandler {
+        @Inject
+        RequestIdProvider requestIdProvider
+
+        LambdaContextSpecHandler(ApplicationContextBuilder builder) {
+            super(builder)
+        }
+
+        @Override
+        protected String resolveFunctionName(Environment env) {
+            "contextrequestid"
+        }
+    }
+
+    @Requires(property = "spec.name", value = "MicronautStreamHandlerLambdaContextSpec")
+    @FunctionBean("contextrequestid")
+    static class ContextRequestIdFunction implements Function<String, String> {
+        private final RequestIdProvider requestIdProvider;
+        ContextRequestIdFunction(RequestIdProvider requestIdProvider) {
+            this.requestIdProvider = requestIdProvider
+        }
+
+        @Override
+        String apply(String s) {
+            requestIdProvider.requestId().orElse(s)
+        }
+    }
+
+    static Context createContextWithoutCollaborators() {
+        new Context() {
+            @Override
+            String getAwsRequestId() {
+                'XXX'
+            }
+
+            @Override
+            String getLogGroupName() {
+                null
+            }
+
+            @Override
+            String getLogStreamName() {
+                null
+            }
+
+            @Override
+            String getFunctionName() {
+                null
+            }
+
+            @Override
+            String getFunctionVersion() {
+                null
+            }
+
+            @Override
+            String getInvokedFunctionArn() {
+                null
+            }
+
+            @Override
+            CognitoIdentity getIdentity() {
+                null
+            }
+
+            @Override
+            ClientContext getClientContext() {
+                null
+            }
+
+            @Override
+            int getRemainingTimeInMillis() {
+                return 0
+            }
+
+            @Override
+            int getMemoryLimitInMB() {
+                return 0
+            }
+
+            @Override
+            LambdaLogger getLogger() {
+                null
+            }
+        }
+    }
+    static Context createContext() {
+        return new Context() {
+            @Override
+            String getAwsRequestId() {
+                return "XXX"
+            }
+
+            @Override
+            String getLogGroupName() {
+                null
+            }
+
+            @Override
+            String getLogStreamName() {
+                null
+            }
+
+            @Override
+            String getFunctionName() {
+                null
+            }
+
+            @Override
+            String getFunctionVersion() {
+                null
+            }
+
+            @Override
+            String getInvokedFunctionArn() {
+                null
+            }
+
+            @Override
+            CognitoIdentity getIdentity() {
+                new CognitoIdentity() {
+                    @Override
+                    String getIdentityId() {
+                        return "identityIDXXX"
+                    }
+
+                    @Override
+                    String getIdentityPoolId() {
+                        return "identityPoolIdXXX"
+                    }
+                }
+            }
+
+            @Override
+            ClientContext getClientContext() {
+                new ClientContext() {
+                    @Override
+                    Client getClient() {
+                        return new Client() {
+                            @Override
+                            String getInstallationId() {
+                                return "installationId"
+                            }
+
+                            @Override
+                            String getAppTitle() {
+                                null
+                            }
+
+                            @Override
+                            String getAppVersionName() {
+                                null
+                            }
+
+                            @Override
+                            String getAppVersionCode() {
+                                null
+                            }
+
+                            @Override
+                            String getAppPackageName() {
+                                null
+                            }
+                        }
+                    }
+
+                    @Override
+                    Map<String, String> getCustom() {
+                        null
+                    }
+
+                    @Override
+                    Map<String, String> getEnvironment() {
+                        null
+                    }
+                }
+            }
+
+            @Override
+            int getRemainingTimeInMillis() {
+                return 0
+            }
+
+            @Override
+            int getMemoryLimitInMB() {
+                return 0
+            }
+
+            @Override
+            LambdaLogger getLogger() {
+                return new LambdaLogger() {
+                    @Override
+                    void log(String message) {
+
+                    }
+
+                    @Override
+                    void log(byte[] message) {
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandler.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandler.groovy
@@ -1,8 +1,15 @@
 package io.micronaut.function.aws
 
+import io.micronaut.context.ApplicationContextBuilder
 import jakarta.inject.Inject
 
 class SquareHandler extends MicronautRequestHandler<Integer, Integer> {
+    SquareHandler() {
+    }
+
+    SquareHandler(ApplicationContextBuilder applicationContextBuilder) {
+        super(applicationContextBuilder)
+    }
 
     @Inject
     SquareService squareService

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandlerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/SquareHandlerSpec.groovy
@@ -22,14 +22,14 @@ class SquareHandlerSpec extends Specification {
 
     def "test using detached mock"() {
         given:
-        def handler = new SquareHandler()
+        SquareHandler handler = new SquareHandler()
         def appCtx = handler.buildApplicationContext(lambdaCtx)
-        def squareService = appCtx.getBean(SquareService)
+        SquareService squareService = appCtx.getBean(SquareService)
         assert mockUtil.isMock(squareService)
         mockUtil.attachMock(squareService, this)
 
         when:
-        def result = handler.handleRequest(2, lambdaCtx)
+        Integer result = handler.handleRequest(2, lambdaCtx)
 
         then:
         squareService.square(_) >> 4

--- a/src/main/docs/guide/lambda/lambdacontext.adoc
+++ b/src/main/docs/guide/lambda/lambdacontext.adoc
@@ -1,0 +1,9 @@
+Lambda Context is registered as a singleton each time the handler gets invoked. You can inject it by using:
+
+- `@Any BeanProvider<com.amazonaws.services.lambda.runtime.Context> context`
+
+If present in the Lambda Context, the following singletons are registered, and you can inject them:
+
+- `@Any BeanProvider<CognitoIdentity> context`
+- `@Any BeanProvider<ClientContext> context`
+- `@Any BeanProvider<LambdaLogger> context`

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -37,6 +37,7 @@ lambda:
   awslambdaruntimes: AWS Lambda Runtimes
   applicationtyperuntimedependencies: Application Types, Lambda Runtimes, Dependencies
   lambdatriggers: Lambda Triggers
+  lambdacontext: Lambda Context
   requestHandlers: Lambda Handlers
   coldstartups: Cold Startups
   customRuntimes: GraalVM and AWS Custom runtimes


### PR DESCRIPTION
Fixes: https://github.com/micronaut-projects/micronaut-aws/issues/1332
Fixes: https://github.com/micronaut-projects/micronaut-aws/issues/1326

This is first attempt to generalize adding diagnostic information to lambda handler despite significant difference between `MicronautRequestHandler` and `MicronautLambdaHandler`. See also #1287 

I'll update documentation and add test when receive a green light for choosen approach.

@graemerocher and @sdelamo your comments are welcome especially regarding bean initialization and registration.