### PR TITLE
fix: AWS Proxy DELETE req without empty body

### DIFF
--- a/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/DeleteWithoutBodySpec.groovy
+++ b/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/DeleteWithoutBodySpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.function.aws.proxy.test
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.*
+import io.micronaut.http.annotation.*
+import io.micronaut.http.client.HttpClient
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class DeleteWithoutBodySpec extends Specification {
+    @Inject
+    @Client('/')
+    HttpClient client
+
+    void "verifies it is possible to exposes a delete endpoint which is invoked without a body"() {
+        given:
+        HttpRequest<?> request = HttpRequest.DELETE("/sessions/sergio")
+
+        when:
+        HttpResponse<?> response = client.toBlocking().exchange(request)
+
+        then:
+        noExceptionThrown()
+
+        and:
+        response.status() == HttpStatus.OK
+    }
+
+    @Controller('/sessions')
+    static class SessionsController {
+        @Delete(value = "/{username}", produces = MediaType.TEXT_PLAIN)
+        String test() {
+            'delete'
+        }
+    }
+}

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/DeleteWithoutBodySpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/DeleteWithoutBodySpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.function.aws.proxy
+
+import com.amazonaws.serverless.proxy.internal.testutils.AwsProxyRequestBuilder
+import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse
+import com.amazonaws.services.lambda.runtime.Context
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpHeaderValues
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpMethod
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Delete
+import io.micronaut.http.annotation.Header
+import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.Status
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class DeleteWithoutBodySpec extends Specification {
+    @Shared @AutoCleanup MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
+            ApplicationContext.builder().properties([
+                    'micronaut.security.enabled': false,
+                    'spec.name': 'DeleteWithoutBodySpec'
+            ])
+    )
+    @Shared Context lambdaContext = new MockLambdaContext()
+
+    void "verifies it is possible to exposes a delete endpoint which is invoked without a body"() {
+        given:
+        AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/sessions/sergio', HttpMethod.DELETE.toString())
+                .header(HttpHeaders.AUTHORIZATION, HttpHeaderValues.AUTHORIZATION_PREFIX_BEARER + " xxx")
+
+        when:
+        AwsProxyResponse response = handler.proxy(builder.build(), lambdaContext)
+
+        then:
+        response.statusCode == 200
+    }
+
+    @Requires(property = 'spec.name', value = 'DeleteWithoutBodySpec')
+    @Controller('/sessions')
+    static class SessionsController {
+        @Status(HttpStatus.OK)
+        @Delete("/{username}")
+        void delete(@PathVariable String username,
+                    @Header(HttpHeaders.AUTHORIZATION) String authorization) {
+        }
+    }
+}


### PR DESCRIPTION
It checks if the body is not null or an empty string. 

Without this I aws getting the following error when invoking an DELETE endpoint with an empty body: 

```

ERROR i.m.http.server.RouteExecutor - Unexpected error occurred: Error decoding JSON stream for type [JsonNode]: No content to map due to end-of-input
 at [Source: (ByteArrayInputStream); line: 1, column: 0]
io.micronaut.http.codec.CodecException: Error decoding JSON stream for type [JsonNode]: No content to map due to end-of-input
 at [Source: (ByteArrayInputStream); line: 1, column: 0]
	at io.micronaut.json.codec.MapperMediaTypeCodec.decode(MapperMediaTypeCodec.java:148)
	at io.micronaut.http.codec.MediaTypeCodec.decode(MediaTypeCodec.java:141)
	at io.micronaut.http.codec.MediaTypeCodec.decode(MediaTypeCodec.java:208)
	at io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler.decodeRequestBody(MicronautLambdaContainerHandler.java:428)
	at io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler.handleRouteMatch(MicronautLambdaContainerHandler.java:334)
	at io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler.lambda$handleRequest$2(MicronautLambdaContainerHandler.java:315)
	at io.micronaut.http.context.ServerRequestContext.with(ServerRequestContext.java:68)
	at io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler.handleRequest(MicronautLambdaContainerHandler.java:307)
	at io.micronaut.function.aws.proxy.MicronautLambdaContainerHandler.handleRequest(MicronautLambdaContainerHandler.java:93)
	at io.micronaut.function.aws.proxy.AbstractLambdaContainerHandler.proxy(AbstractLambdaContainerHandler.java:205)
	at io.micronaut.function.aws.proxy.MicronautLambdaHandler.handleRequest(MicronautLambdaHandler.java:68)
	at io.micronaut.function.aws.proxy.test.AwsApiProxyTestServer$AwsProxyHandler.handle(AwsApiProxyTestServer.java:201)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:773)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:905)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
 at [Source: (ByteArrayInputStream); line: 1, column: 0]
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.ObjectMapper._initForReading(ObjectMapper.java:4765)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4667)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3682)
	at io.micronaut.jackson.databind.JacksonDatabindMapper.readValue(JacksonDatabindMapper.java:114)
	at io.micronaut.json.codec.MapperMediaTypeCodec.decode(MapperMediaTypeCodec.java:146)
	... 23 common frames omitted
```