### PR TITLE
fix: Only attempt to decode base64 if body != null

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyRequest.java
@@ -275,7 +275,7 @@ public class MicronautAwsProxyRequest<T> implements HttpRequest<T> {
             return Optional.of(decodedBody);
         }
         final String body = awsProxyRequest.getBody();
-        if (awsProxyRequest.isBase64Encoded()) {
+        if (awsProxyRequest.isBase64Encoded() && body != null) {
             return (Optional<T>) Optional.ofNullable(Base64.getMimeDecoder().decode(body));
         }
         return (Optional<T>) Optional.ofNullable(body);


### PR DESCRIPTION
When using AWS and OAuth 2.0 I get the following exception

```
java.lang.NullPointerException: null
	at java.base/java.util.Base64$Decoder.decode(Base64.java:561)
	at io.micronaut.function.aws.proxy.MicronautAwsProxyRequest.getBody(MicronautAwsProxyRequest.java:279)
	at io.micronaut.security.oauth2.client.ClientUtils.getResponseData(ClientUtils.java:36)
	at io.micronaut.security.oauth2.client.DefaultOpenIdClient.onCallback(DefaultOpenIdClient.java:130)
```