### PR TITLE
Duplicate decoding of query parameters arriving from Api Gateway proxy

### DIFF
--- a/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServerSpec.groovy
+++ b/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServerSpec.groovy
@@ -45,6 +45,15 @@ class AwsApiProxyTestServerSpec extends Specification {
         then:
         result == 'get:bar'
     }
+    
+    void 'query values with special chars are not double decoded'() {
+        when:
+        String result = client.toBlocking().retrieve(HttpRequest.GET('/test-param?foo=prebar%2Bpostbar')
+                                        .contentType(MediaType.TEXT_PLAIN), String)
+
+        then:
+        result == 'get:prebar+postbar'
+    }
 
 
     @Controller

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyRequest.java
@@ -444,7 +444,7 @@ public class MicronautAwsProxyRequest<T> implements HttpRequest<T> {
         @Nullable
         @Override
         public String get(CharSequence name) {
-        	if (StringUtils.isNotEmpty(name)) {
+            if (StringUtils.isNotEmpty(name)) {
                 return params.getFirst(name.toString());
             }
             return null;

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ParametersSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/ParametersSpec.groovy
@@ -28,13 +28,14 @@ class ParametersSpec extends Specification {
         AwsProxyRequestBuilder builder = new AwsProxyRequestBuilder('/parameters-test/all', HttpMethod.GET.toString())
         builder.queryString("test", "one")
         builder.queryString("test", "two")
+        builder.queryString("test", "three+four")
 
         when:
         def response = handler.proxy(builder.build(), lambdaContext)
 
         then:
         response.statusCode == 200
-        response.body == '["one","two"]'
+        response.body == '["one","two","three+four"]'
     }
 
     @Controller('/parameters-test')


### PR DESCRIPTION
Fix for the issue with duplicate decoding of query parameters arriving from Api Gateway proxy (https://github.com/micronaut-projects/micronaut-aws/issues/1407).




Results from testing the changes on AWS (Aws Api Gateway Lambda proxy integration):
`curl https://<AWS_GATEWAY_API_URL_PREFIX>.execute-api.us-east-1.amazonaws.com/test/mypath?testparam=aa%2Bbb
{"testparam":"aa+bb"}`