### PR TITLE
Allow overriding the endpoint via configuration

### DIFF
--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ClientFactory.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ClientFactory.java
@@ -56,8 +56,12 @@ public class S3ClientFactory extends AwsClientFactory<S3ClientBuilder, S3AsyncCl
 
     @Override
     protected S3ClientBuilder createSyncBuilder() {
-        return S3Client.builder()
-                .serviceConfiguration(configuration.getBuilder().build());
+       S3ClientBuilder builder = S3Client.builder();
+       if (configuration.getEndpointOverride() != null) {
+           builder.endpointOverride(configuration.getEndpointOverride());
+       }
+       builder.serviceConfiguration(configuration.getBuilder().build());
+        return builder;
     }
 
     @Override

--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
@@ -22,6 +22,8 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3Configuration.Builder;
 
+import java.net.URI;
+
 /**
  * Configuration properties for S3.
  *
@@ -34,10 +36,26 @@ public class S3ConfigurationProperties extends AWSConfiguration {
     @ConfigurationBuilder(prefixes = {""}, excludes = {"profileFile", "applyMutation"})
     private Builder builder = S3Configuration.builder();
 
+    private URI endpointOverride;
+
     /**
      * @return The builder
      */
     public Builder getBuilder() {
         return builder;
+    }
+
+    /**
+     * @return The endpoint with which the AWS SDK should communicate
+     */
+    public URI getEndpointOverride() {
+        return endpointOverride;
+    }
+
+    /**
+     * @param endpointOverride The endpoint with which the AWS SDK should communicate
+     */
+    public void setEndpointOverride(URI endpointOverride) {
+        this.endpointOverride = endpointOverride;
     }
 }

--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
@@ -57,6 +57,7 @@ public class S3ConfigurationProperties extends AWSConfiguration {
     }
 
     /**
+     * Provide a URI to override the endpoint with which the AWS SDK should communicate. Optional. Defaults to `null`.
      * @param endpointOverride The endpoint with which the AWS SDK should communicate
      * @since 3.6.2
      */

--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
@@ -47,6 +47,7 @@ public class S3ConfigurationProperties extends AWSConfiguration {
 
     /**
      * @return The endpoint with which the AWS SDK should communicate
+     * @since 3.6.2
      */
     public URI getEndpointOverride() {
         return endpointOverride;
@@ -54,6 +55,7 @@ public class S3ConfigurationProperties extends AWSConfiguration {
 
     /**
      * @param endpointOverride The endpoint with which the AWS SDK should communicate
+     * @since 3.6.2
      */
     public void setEndpointOverride(URI endpointOverride) {
         this.endpointOverride = endpointOverride;

--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/s3/S3ConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.micronaut.aws.sdk.v2.service.s3;
 import io.micronaut.aws.AWSConfiguration;
 import io.micronaut.context.annotation.ConfigurationBuilder;
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Nullable;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3Configuration.Builder;
@@ -36,6 +37,7 @@ public class S3ConfigurationProperties extends AWSConfiguration {
     @ConfigurationBuilder(prefixes = {""}, excludes = {"profileFile", "applyMutation"})
     private Builder builder = S3Configuration.builder();
 
+    @Nullable
     private URI endpointOverride;
 
     /**
@@ -49,6 +51,7 @@ public class S3ConfigurationProperties extends AWSConfiguration {
      * @return The endpoint with which the AWS SDK should communicate
      * @since 3.6.2
      */
+    @Nullable
     public URI getEndpointOverride() {
         return endpointOverride;
     }
@@ -57,7 +60,7 @@ public class S3ConfigurationProperties extends AWSConfiguration {
      * @param endpointOverride The endpoint with which the AWS SDK should communicate
      * @since 3.6.2
      */
-    public void setEndpointOverride(URI endpointOverride) {
+    public void setEndpointOverride(@Nullable URI endpointOverride) {
         this.endpointOverride = endpointOverride;
     }
 }

--- a/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/service/S3ClientSpec.groovy
+++ b/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/service/S3ClientSpec.groovy
@@ -1,10 +1,21 @@
 package io.micronaut.aws.sdk.v2.service
 
 import io.micronaut.aws.sdk.v2.ApplicationContextSpecification
+import software.amazon.awssdk.core.client.config.SdkClientOption
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.S3ClientBuilder
 
 class S3ClientSpec extends ApplicationContextSpecification {
+
+    private static final String ENDPOINT = "https://localhost:1234"
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                "aws.s3.endpoint-override": ENDPOINT
+        ]
+    }
 
     void "it can configure an S3 client"() {
         when:
@@ -20,5 +31,13 @@ class S3ClientSpec extends ApplicationContextSpecification {
 
         then:
         client.serviceName() == S3Client.SERVICE_NAME
+    }
+
+    void "it can override endpoint"() {
+        when:
+        S3ClientBuilder builder = applicationContext.getBean(S3ClientBuilder)
+
+        then:
+        builder.syncClientConfiguration().option(SdkClientOption.ENDPOINT).toString() == ENDPOINT
     }
 }


### PR DESCRIPTION
Overriding the S3 endpoint is required when using services such as Localstack, or when using an S3 client for any S3-compatible storage service.

Before this change, users would need to implement a `BeanCreatedEventListener` to programmatically set the endpoint. This PR allows setting the endpoint via configuration