### PR TITLE
Log context initialization errors

### DIFF
--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -40,11 +40,6 @@ import java.util.Optional;
  */
 public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExecutor<I, O, Context> implements RequestHandler<I, O>, MicronautLambdaContext {
 
-    /**
-     * Logger for the application context creation errors.
-     */
-    private static final Logger LOG = LoggerFactory.getLogger(MicronautRequestHandler.class);
-
     public static final String ENV_X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
 
     // See: https://github.com/aws/aws-xray-sdk-java/issues/251
@@ -91,6 +86,11 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
      */
     @Deprecated
     public static final String MDC_DEFAULT_XRAY_TRACE_ID = "AWS-XRAY-TRACE-ID";
+
+    /**
+     * Logger for the application context creation errors.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MicronautRequestHandler.class);
 
     @SuppressWarnings("unchecked")
     private final Class<I> inputType = initTypeArgument();

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -120,7 +120,7 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
             startEnvironment(applicationContext);
             injectIntoApplicationContext();
         } catch (Exception e) {
-            LOG.error("Exception initializing handler", e);
+            LOG.error("Exception initializing handler: " + e.getMessage() , e);
             throw e;
         }
     }

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestHandler.java
@@ -25,6 +25,8 @@ import io.micronaut.core.convert.ConversionError;
 import io.micronaut.core.reflect.GenericTypeUtils;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.function.executor.AbstractFunctionExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import java.util.Optional;
 
@@ -37,6 +39,11 @@ import java.util.Optional;
  * @since 1.0
  */
 public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExecutor<I, O, Context> implements RequestHandler<I, O>, MicronautLambdaContext {
+
+    /**
+     * Logger for the application context creation errors.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MicronautRequestHandler.class);
 
     public static final String ENV_X_AMZN_TRACE_ID = "_X_AMZN_TRACE_ID";
 
@@ -93,8 +100,13 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
      * Lambda deployment.
      */
     public MicronautRequestHandler() {
-        buildApplicationContext(null);
-        injectIntoApplicationContext();
+        try {
+            buildApplicationContext(null);
+            injectIntoApplicationContext();
+        } catch (Exception e) {
+            LOG.error("Exception initializing handler", e);
+            throw e;
+        }
     }
 
     /**
@@ -103,8 +115,14 @@ public abstract class MicronautRequestHandler<I, O> extends AbstractFunctionExec
      */
     public MicronautRequestHandler(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
-        startEnvironment(applicationContext);
-        injectIntoApplicationContext();
+
+        try {
+            startEnvironment(applicationContext);
+            injectIntoApplicationContext();
+        } catch (Exception e) {
+            LOG.error("Exception initializing handler", e);
+            throw e;
+        }
     }
 
     /**

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -57,7 +57,7 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
         try {
             buildApplicationContext(null);
         } catch (Exception e) {
-            LOG.error("Exception initializing handler", e);
+            LOG.error("Exception initializing handler: " + e.getMessage(), e);
             throw e;
         }
     }

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static io.micronaut.function.aws.MicronautRequestHandler.registerContextBeans;
-
 /**
  * <p>An implementation of the {@link RequestStreamHandler} for Micronaut</p>.
  *

--- a/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/MicronautRequestStreamHandler.java
@@ -23,6 +23,9 @@ import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.function.executor.StreamFunctionExecutor;
 import io.micronaut.core.annotation.NonNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -37,6 +40,11 @@ import static io.micronaut.function.aws.MicronautRequestHandler.registerContextB
  */
 public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Context> implements RequestStreamHandler, MicronautLambdaContext {
 
+    /**
+     * Logger for the application context creation errors.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MicronautRequestStreamHandler.class);
+
     @Nullable
     private String ctxFunctionName;
 
@@ -48,7 +56,12 @@ public class MicronautRequestStreamHandler extends StreamFunctionExecutor<Contex
         // initialize the application context in the constructor
         // this is faster in Lambda as init cost is giving higher processor priority
         // see https://github.com/micronaut-projects/micronaut-aws/issues/18#issuecomment-530903419
-        buildApplicationContext(null);
+        try {
+            buildApplicationContext(null);
+        } catch (Exception e) {
+            LOG.error("Exception initializing handler", e);
+            throw e;
+        }
     }
 
     /**


### PR DESCRIPTION
In case of using an external system to monitor errors such as Sentry there is currently no way how to forward context creation errors into the system. 

When there is an issue with the `ApplicationContext` such as missing property then the errors are only logged into CloudWatch which is not sufficient.

Logging the errors in the constructor where they initialization happens is the best way how to keep track of these issues.