### PR TITLE
fix: test with APIGatewayProxy

### DIFF
--- a/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/RuntimeApiSpec.groovy
+++ b/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/RuntimeApiSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.function.aws.runtime
 import com.amazonaws.serverless.proxy.model.ApiGatewayRequestIdentity
 import com.amazonaws.serverless.proxy.model.AwsProxyRequest
 import com.amazonaws.serverless.proxy.model.AwsProxyRequestContext
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse
 import com.amazonaws.services.lambda.runtime.Context
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanProvider
@@ -37,7 +38,7 @@ class RuntimeApiSpec extends Specification {
         new PollingConditions(timeout: 5).eventually {
             assert lambadaRuntimeApi.responses
             assert lambadaRuntimeApi.responses['123456']
-            assert lambadaRuntimeApi.responses['123456'].contains('body":"Hello 123456"')
+            assert lambadaRuntimeApi.responses['123456'].body == "Hello 123456"
         }
 
         cleanup:
@@ -76,7 +77,7 @@ class RuntimeApiSpec extends Specification {
     @Controller("/")
     static class MockLambadaRuntimeApi {
 
-        Map<String, String> responses = [:]
+        Map<String, AwsProxyResponse> responses = [:]
 
         @Get("/2018-06-01/runtime/invocation/next")
         HttpResponse<AwsProxyRequest> next() {
@@ -92,8 +93,8 @@ class RuntimeApiSpec extends Specification {
         }
 
         @Post("/2018-06-01/runtime/invocation/{requestId}/response")
-        HttpResponse<?> response(@PathVariable("requestId") String requestId, @Body String body) {
-            responses[requestId] = body
+        HttpResponse<?> response(@PathVariable("requestId") String requestId, @Body AwsProxyResponse proxyResponse) {
+            responses[requestId] = proxyResponse
             return HttpResponse.accepted()
         }
     }

--- a/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/RuntimeApiSpec.groovy
+++ b/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/RuntimeApiSpec.groovy
@@ -1,31 +1,13 @@
-/*
- * Copyright 2017-2019 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.micronaut.function.aws.runtime
 
 import com.amazonaws.serverless.proxy.model.ApiGatewayRequestIdentity
 import com.amazonaws.serverless.proxy.model.AwsProxyRequest
 import com.amazonaws.serverless.proxy.model.AwsProxyRequestContext
-import com.amazonaws.serverless.proxy.model.AwsProxyResponse
 import com.amazonaws.services.lambda.runtime.Context
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.BeanProvider
 import io.micronaut.context.annotation.Any
 import io.micronaut.context.annotation.Requires
-import io.micronaut.function.aws.MicronautRequestHandler
-import io.micronaut.http.HttpHeaders
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.MediaType
 import io.micronaut.http.annotation.Body
@@ -37,42 +19,15 @@ import io.micronaut.http.annotation.Produces
 import io.micronaut.runtime.server.EmbeddedServer
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
-import spock.util.environment.RestoreSystemProperties
 
-class MicronautLambdaRuntimeSpec extends Specification {
-
-    @RestoreSystemProperties
-    void "Tracing header propagated as system property"() {
+class RuntimeApiSpec extends Specification {
+    void "test runtime API loop"() {
         given:
-        String traceHeader = 'Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1'
-        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'MicronautLambdaRuntimeSpec'])
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'RuntimeApiSpec'])
         String serverUrl = "localhost:$embeddedServer.port"
         CustomMicronautLambdaRuntime customMicronautLambdaRuntime = new CustomMicronautLambdaRuntime(serverUrl)
         Thread t = new Thread({ ->
             customMicronautLambdaRuntime.run([] as String[])
-        })
-        t.start()
-
-        when:
-        def httpHeaders = Stub(HttpHeaders) {
-            get(LambdaRuntimeInvocationResponseHeaders.LAMBDA_RUNTIME_TRACE_ID) >> traceHeader
-        }
-        customMicronautLambdaRuntime.propagateTraceId(httpHeaders)
-
-        then:
-        System.getProperty(MicronautRequestHandler.LAMBDA_TRACE_HEADER_PROP) == traceHeader
-
-        cleanup:
-        embeddedServer.close()
-    }
-
-    void "test runtime API loop"() {
-        given:
-        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, ['spec.name': 'MicronautLambdaRuntimeSpec'])
-        String serverUrl = "localhost:$embeddedServer.port"
-        CustomMicronautLambdaRuntime customMicronautLambdaRuntime = new CustomMicronautLambdaRuntime(serverUrl)
-        Thread t = new Thread({ ->
-             customMicronautLambdaRuntime.run([] as String[])
         })
         t.start()
 
@@ -117,7 +72,7 @@ class MicronautLambdaRuntimeSpec extends Specification {
         }
     }
 
-    @Requires(property = 'spec.name', value = 'MicronautLambdaRuntimeSpec')
+    @Requires(property = 'spec.name', value = 'RuntimeApiSpec')
     @Controller("/")
     static class MockLambadaRuntimeApi {
 
@@ -133,7 +88,7 @@ class MicronautLambdaRuntimeSpec extends Specification {
             context.setIdentity(new ApiGatewayRequestIdentity())
             req.setRequestContext(context)
             HttpResponse.ok(req)
-                .header(LambdaRuntimeInvocationResponseHeaders.LAMBDA_RUNTIME_AWS_REQUEST_ID, "123456")
+                    .header(LambdaRuntimeInvocationResponseHeaders.LAMBDA_RUNTIME_AWS_REQUEST_ID, "123456")
         }
 
         @Post("/2018-06-01/runtime/invocation/{requestId}/response")
@@ -142,5 +97,4 @@ class MicronautLambdaRuntimeSpec extends Specification {
             return HttpResponse.accepted()
         }
     }
-
 }

--- a/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/TracingHeaderPropagationSysPropertySpec.groovy
+++ b/function-aws-custom-runtime/src/test/groovy/io/micronaut/function/aws/runtime/TracingHeaderPropagationSysPropertySpec.groovy
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017-2019 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.runtime
+
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.function.aws.MicronautRequestHandler
+import io.micronaut.http.HttpHeaders
+import io.micronaut.runtime.server.EmbeddedServer
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class TracingHeaderPropagationSysPropertySpec extends Specification {
+
+    @RestoreSystemProperties
+    void "Tracing header propagated as system property"() {
+        given:
+        String traceHeader = 'Root=1-5759e988-bd862e3fe1be46a994272793;Sampled=1'
+        EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer, [:])
+        String serverUrl = "localhost:$embeddedServer.port"
+        CustomMicronautLambdaRuntime customMicronautLambdaRuntime = new CustomMicronautLambdaRuntime(serverUrl)
+        Thread t = new Thread({ ->
+            customMicronautLambdaRuntime.run([] as String[])
+        })
+        t.start()
+
+        when:
+        def httpHeaders = Stub(HttpHeaders) {
+            get(LambdaRuntimeInvocationResponseHeaders.LAMBDA_RUNTIME_TRACE_ID) >> traceHeader
+        }
+        customMicronautLambdaRuntime.propagateTraceId(httpHeaders)
+
+        then:
+        System.getProperty(MicronautRequestHandler.LAMBDA_TRACE_HEADER_PROP) == traceHeader
+
+        cleanup:
+        embeddedServer.close()
+    }
+
+    class CustomMicronautLambdaRuntime extends MicronautLambdaRuntime {
+
+        String serverUrl
+
+        CustomMicronautLambdaRuntime(String serverUrl) {
+            super()
+            this.serverUrl = serverUrl
+        }
+
+        @Override
+        String getEnv(String name) {
+            if (name == ReservedRuntimeEnvironmentVariables.AWS_LAMBDA_RUNTIME_API) {
+                return serverUrl
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=3.9.0-SNAPSHOT
 projectGroup=io.micronaut.aws
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.6.1
+micronautVersion=3.5.5
 micronautTestVersion=3.5.0
 
 groovyVersion=3.0.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=3.9.0-SNAPSHOT
 projectGroup=io.micronaut.aws
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.6.1
+micronautVersion=3.6.2
 micronautTestVersion=3.5.0
 
 groovyVersion=3.0.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectVersion=3.9.0-SNAPSHOT
 projectGroup=io.micronaut.aws
 
 micronautDocsVersion=2.0.0
-micronautVersion=3.5.5
+micronautVersion=3.6.1
 micronautTestVersion=3.5.0
 
 groovyVersion=3.0.10


### PR DESCRIPTION
I had to dowgrade to 3.5.5 

because the Body string received with `3.6.2` here:

```java
@Post("/2018-06-01/runtime/invocation/{requestId}/response")
        HttpResponse<?> response(@PathVariable("requestId") String requestId, @Body String body) {
```

is : 

` PooledSlicedByteBuf(ridx: 0, widx: 156, cap: 156/156, unwrapped: PooledUnsafeDirectByteBuf(ridx: 364, widx: 364, cap: 2048))`

@yawkat any idea what could be the culprit?

 