### PR TITLE
Remove discovery dependency from AWS logging

### DIFF
--- a/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
+++ b/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
@@ -19,7 +19,6 @@ import io.micronaut.context.annotation.Context;
 import io.micronaut.context.event.ApplicationEventListener;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
-import io.micronaut.discovery.event.ServiceReadyEvent;
 import io.micronaut.runtime.ApplicationConfiguration;
 import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.annotation.PreDestroy;

--- a/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
+++ b/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.discovery.event.ServiceReadyEvent;
 import io.micronaut.runtime.ApplicationConfiguration;
+import io.micronaut.runtime.server.event.ServerStartupEvent;
 import jakarta.annotation.PreDestroy;
 import jakarta.inject.Singleton;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
@@ -43,7 +44,7 @@ import java.util.Optional;
 @Context
 @Internal
 @Singleton
-final class CloudWatchLoggingClient implements ApplicationEventListener<ServiceReadyEvent> {
+final class CloudWatchLoggingClient implements ApplicationEventListener<ServerStartupEvent> {
 
     private static CloudWatchLogsClient logging;
     private static String host;
@@ -122,7 +123,7 @@ final class CloudWatchLoggingClient implements ApplicationEventListener<ServiceR
     }
 
     @Override
-    public void onApplicationEvent(ServiceReadyEvent event) {
+    public void onApplicationEvent(ServerStartupEvent event) {
         setLogging(internalLogging, event.getSource().getHost(), internalAppName);
     }
 

--- a/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
+++ b/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
@@ -5,8 +5,6 @@ import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.PatternLayout
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder
-import io.micronaut.discovery.ServiceInstance
-import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.runtime.server.event.ServerStartupEvent

--- a/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
+++ b/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
@@ -8,6 +8,8 @@ import ch.qos.logback.core.encoder.LayoutWrappingEncoder
 import io.micronaut.discovery.ServiceInstance
 import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.runtime.ApplicationConfiguration
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.server.event.ServerStartupEvent
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
@@ -34,13 +36,13 @@ class CloudWatchLoggingAppenderSpec extends Specification {
         def config = Stub(ApplicationConfiguration) {
             getName() >> Optional.of("my-awesome-app")
         }
-        def instance = Mock(ServiceInstance.class)
+        def instance = Mock(EmbeddedServer.class)
         instance.getHost() >> "testHost"
-        def serviceReadyEvent = new ServiceReadyEvent(instance)
+        def serverStartupEvent = new ServerStartupEvent(instance)
 
         cloudWatchLogsClient = new CloudwatchLoggingSpec.MockLogging()
 
-        new CloudWatchLoggingClient(cloudWatchLogsClient, config).onApplicationEvent(serviceReadyEvent)
+        new CloudWatchLoggingClient(cloudWatchLogsClient, config).onApplicationEvent(serverStartupEvent)
 
     }
 

--- a/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudwatchLoggingSpec.groovy
+++ b/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudwatchLoggingSpec.groovy
@@ -7,6 +7,8 @@ import io.micronaut.context.event.ApplicationEventPublisher
 import io.micronaut.discovery.ServiceInstance
 import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.runtime.ApplicationConfiguration
+import io.micronaut.runtime.server.EmbeddedServer
+import io.micronaut.runtime.server.event.ServerStartupEvent
 import io.micronaut.serde.ObjectMapper
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -28,7 +30,7 @@ class CloudwatchLoggingSpec extends Specification {
     CloudWatchLogsClient logging
 
     @Inject
-    ApplicationEventPublisher<ServiceReadyEvent> eventPublisher
+    ApplicationEventPublisher<ServerStartupEvent> eventPublisher
 
     @Inject
     ApplicationConfiguration applicationConfiguration
@@ -41,9 +43,9 @@ class CloudwatchLoggingSpec extends Specification {
         PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
 
         def mockLogging = (MockLogging) logging
-        def instance = Mock(ServiceInstance.class)
+        def instance = Mock(EmbeddedServer.class)
         instance.getHost() >> testHost
-        def event = new ServiceReadyEvent(instance)
+        def event = new ServerStartupEvent(instance)
         eventPublisher.publishEvent(event)
 
         when:

--- a/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudwatchLoggingSpec.groovy
+++ b/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudwatchLoggingSpec.groovy
@@ -4,8 +4,6 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Replaces
 import io.micronaut.context.annotation.Requires
 import io.micronaut.context.event.ApplicationEventPublisher
-import io.micronaut.discovery.ServiceInstance
-import io.micronaut.discovery.event.ServiceReadyEvent
 import io.micronaut.runtime.ApplicationConfiguration
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.runtime.server.event.ServerStartupEvent


### PR DESCRIPTION
This PR removes unnecessary dependency to microanut-descovery module from AWS Cloud Logging.