### PR TITLE
graal: StsWebIdentityCredentialsProviderFactory class is loaded via reflection

### DIFF
--- a/aws-sdk-v2/src/main/resources/META-INF/native-image/io.micronaut.aws/micronaut-aws-sdk-v2/reflect-config.json
+++ b/aws-sdk-v2/src/main/resources/META-INF/native-image/io.micronaut.aws/micronaut-aws-sdk-v2/reflect-config.json
@@ -13,5 +13,9 @@
   {
     "name":"org.apache.commons.logging.impl.WeakHashtable",
     "methods":[{"name":"<init>","parameterTypes":[] }]
+  },
+  {
+    "name":"software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory",
+    "methods":[{"name":"<init>","parameterTypes":[] }]
   }
 ]


### PR DESCRIPTION
When a native image micronaut service is running in AWS kubernetes cluster, the GetParameters and ListSecrets AWS requests fail because AWS_WEB_IDENTITY_TOKEN_FILE and AWS_ROLE_ARN environment variables are not used for authentication. Those env variables are not used because `software.amazon.awssdk.auth.credentials.internal.WebIdentityCredentialsUtils` class is using reflection to load and create an instance of `software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory` class. The issue can be seen here too:
```
https://github.com/aws/aws-sdk-java-v2/issues/2985
```