### PR TITLE
Use new RequestLifecycle api

### DIFF
--- a/aws-cloudwatch-logging/build.gradle.kts
+++ b/aws-cloudwatch-logging/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
     implementation(libs.logback.json.classic)
     api(libs.awssdk.cloudwatchlogs)
     api(mn.micronaut.runtime)
-    api(mn.micronaut.serde.jackson)
+    api(mnSerde.micronaut.serde.jackson)
     testRuntimeOnly(mn.snakeyaml)
 }

--- a/aws-distributed-configuration/build.gradle.kts
+++ b/aws-distributed-configuration/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
     api(projects.awsCommon)
-    api(mn.micronaut.discovery)
+    api(mn.micronaut.discovery.core)
     testImplementation(mn.micronaut.http.server.netty)
 }

--- a/aws-distributed-configuration/build.gradle.kts
+++ b/aws-distributed-configuration/build.gradle.kts
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
     api(projects.awsCommon)
-    api(mn.micronaut.discovery.core)
+    api(libs.micronaut.discovery.client)
     testImplementation(mn.micronaut.http.server.netty)
 }

--- a/aws-parameter-store/build.gradle.kts
+++ b/aws-parameter-store/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(mn.micronaut.discovery)
+    api(mn.micronaut.discovery.core)
     api(projects.awsServiceDiscovery)
     api(projects.awsSdkV2)
     implementation(libs.aws.ssm)

--- a/aws-sdk-v2/build.gradle.kts
+++ b/aws-sdk-v2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     api(platform(libs.boms.aws.java.sdk.v2))
     api(projects.awsCommon)
-    compileOnly(mn.graal)
+    compileOnly(libs.graal.sdk)
 
     // Clients
     compileOnly(libs.awssdk.url.connection.client)

--- a/aws-service-discovery/build.gradle.kts
+++ b/aws-service-discovery/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(mn.micronaut.discovery)
+    api(mn.micronaut.discovery.core)
     api(projects.awsSdkV2)
     implementation(libs.awssdk.servicediscovery)
     implementation(mn.micronaut.jackson.databind)

--- a/aws-service-discovery/build.gradle.kts
+++ b/aws-service-discovery/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(mn.micronaut.discovery.core)
+    api(libs.micronaut.discovery.client)
     api(projects.awsSdkV2)
     implementation(libs.awssdk.servicediscovery)
     implementation(mn.micronaut.jackson.databind)

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.aws-base.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.aws-base.gradle
@@ -1,4 +1,5 @@
 repositories {
+    mavenLocal()
     mavenCentral()
     maven { url "https://s01.oss.sonatype.org/content/repositories/snapshots/" }
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,7 +96,7 @@
         <!-- Checks for Javadoc comments.                     -->
         <!-- See https://checkstyle.org/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="excludeScope" value="private"/>
+            <property name="accessModifiers" value="public,protected"/>
         </module>
         <module name="JavadocType"/>
         <module name="JavadocStyle"/>

--- a/function-aws-api-proxy/build.gradle.kts
+++ b/function-aws-api-proxy/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor(mn.micronaut.graal)
-    compileOnly(mn.micronaut.security)
+    annotationProcessor(libs.micronaut.graal)
+    compileOnly(mnSecurity.micronaut.security)
     implementation(mn.micronaut.http.netty)
     implementation(mn.reactor)
     api(mn.micronaut.http.server)
@@ -21,8 +21,8 @@ dependencies {
     testImplementation(mn.micronaut.validation)
     testImplementation(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.http.client)
-    testImplementation(mn.micronaut.security)
-    testImplementation(mn.micronaut.views.handlebars)
+    testImplementation(mnSecurity.micronaut.security)
+    testImplementation(mnViews.micronaut.views.handlebars)
     testImplementation(libs.jackson.afterburner)
     testImplementation(libs.servlet.api)
     testImplementation(libs.fileupload)

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsRequestLifecycle.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsRequestLifecycle.java
@@ -50,7 +50,15 @@ class AwsRequestLifecycle extends RequestLifecycle {
 
     ExecutionFlow<MutableHttpResponse<?>> run() {
         return normalFlow()
-            .flatMap(r -> convertResponseBody(r.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).get(), r.body()))
+            .flatMap(r -> {
+                Optional<RouteInfo> routeInfo = r.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class);
+                if (routeInfo.isPresent()) {
+                    return convertResponseBody(routeInfo.get(), r.body());
+                } else {
+                    // can happen on error
+                    return ExecutionFlow.just(r);
+                }
+            })
             .onErrorResume(this::onError);
     }
 

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsRequestLifecycle.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsRequestLifecycle.java
@@ -1,0 +1,163 @@
+package io.micronaut.function.aws.proxy;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.async.publisher.Publishers;
+import io.micronaut.core.execution.ExecutionFlow;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.type.TypeVariableResolver;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.HttpAttributes;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Consumes;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.annotation.Status;
+import io.micronaut.http.reactive.execution.ReactiveExecutionFlow;
+import io.micronaut.http.server.RequestLifecycle;
+import io.micronaut.http.server.RouteExecutor;
+import io.micronaut.web.router.MethodBasedRouteMatch;
+import io.micronaut.web.router.RouteInfo;
+import io.micronaut.web.router.RouteMatch;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+class AwsRequestLifecycle extends RequestLifecycle {
+    private final MicronautLambdaContainerHandler containerHandler;
+    private final MicronautAwsProxyRequest<?> containerRequest;
+    private final MicronautAwsProxyResponse<?> containerResponse;
+
+    AwsRequestLifecycle(
+        MicronautLambdaContainerHandler containerHandler,
+        RouteExecutor routeExecutor,
+        MicronautAwsProxyRequest<?> containerRequest,
+        MicronautAwsProxyResponse<?> containerResponse) {
+        super(routeExecutor, containerRequest);
+        this.containerHandler = containerHandler;
+        this.containerRequest = containerRequest;
+        this.containerResponse = containerResponse;
+    }
+
+    ExecutionFlow<MutableHttpResponse<?>> run() {
+        return normalFlow()
+            .flatMap(r -> convertResponseBody(r.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).get(), r.body()))
+            .onErrorResume(this::onError);
+    }
+
+    @Override
+    protected ExecutionFlow<RouteMatch<?>> fulfillArguments(RouteMatch<?> routeMatch) {
+        decodeRequestBody(routeMatch)
+            .ifPresent(((MicronautAwsProxyRequest) containerRequest)::setDecodedBody);
+        return super.fulfillArguments(routeMatch);
+    }
+
+    @NonNull
+    private Optional<Object> decodeRequestBody(@NonNull RouteMatch<?> finalRoute) {
+        return containerHandler.mediaTypeBodyDecoder.entrySet()
+            .stream()
+            .map(e -> decodeRequestBody(finalRoute, e))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .findFirst();
+    }
+
+    private Optional<Object> decodeRequestBody(@NonNull RouteMatch<?> finalRoute,
+                                                      @NonNull Map.Entry<MediaType, BiFunction<Argument<?>, String, Optional<Object>>> entry) {
+        return parseUndecodedBody(finalRoute, entry.getKey())
+            .flatMap(body -> decodeRequestBody(body, entry.getValue(), finalRoute));
+    }
+
+    @NonNull
+    private static Optional<Object> decodeRequestBody(@NonNull String body,
+                                                      @NonNull BiFunction<Argument<?>, String, Optional<Object>> function,
+                                                      @NonNull RouteMatch<?> finalRoute) {
+        if (StringUtils.isNotEmpty(body)) {
+            Argument<?> bodyArgument = parseBodyArgument(finalRoute);
+            return function.apply(bodyArgument, body);
+        }
+        return Optional.empty();
+    }
+
+    @Nullable
+    private static Argument<?> parseBodyArgument(@NonNull RouteMatch<?> finalRoute) {
+        Argument<?> bodyArgument = finalRoute.getBodyArgument().orElse(null);
+        if (bodyArgument == null) {
+            if (finalRoute instanceof MethodBasedRouteMatch) {
+                bodyArgument = Arrays.stream(((MethodBasedRouteMatch) finalRoute).getArguments())
+                    .filter(arg -> HttpRequest.class.isAssignableFrom(arg.getType()))
+                    .findFirst()
+                    .flatMap(TypeVariableResolver::getFirstTypeVariable).orElse(null);
+            }
+        }
+        if (bodyArgument != null) {
+            final Class<?> rawType = bodyArgument.getType();
+            if (Publishers.isConvertibleToPublisher(rawType) || HttpRequest.class.isAssignableFrom(rawType)) {
+                bodyArgument = bodyArgument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
+            }
+        }
+        return bodyArgument;
+    }
+
+    @NonNull
+    private Optional<String> parseUndecodedBody(@NonNull RouteMatch<?> finalRoute,
+                                                @NonNull MediaType mediaType) {
+        if (containerRequest.isBodyDecoded()) {
+            return Optional.empty();
+        }
+        if (!HttpMethod.permitsRequestBody(containerRequest.getMethod())) {
+            return Optional.empty();
+        }
+        final MediaType requestContentType = containerRequest.getContentType().orElse(null);
+        if (requestContentType == null) {
+            return Optional.empty();
+        }
+        if (!mediaType.getExtension().equals(requestContentType.getExtension())) {
+            return Optional.empty();
+        }
+        final MediaType[] expectedContentType = finalRoute.getAnnotationMetadata().getValue(Consumes.class, MediaType[].class).orElse(null);
+        return (expectedContentType == null || Arrays.stream(expectedContentType).anyMatch(ct -> mediaType.getExtension().equals(ct.getExtension()))) ?
+            containerRequest.getBody(String.class) :
+            Optional.empty();
+    }
+
+    private ExecutionFlow<MutableHttpResponse<?>> convertResponseBody(RouteInfo<?> routeInfo, Object body) {
+        if (Publishers.isConvertibleToPublisher(body)) {
+            ExecutionFlow<?> single;
+            if (Publishers.isSingle(body.getClass()) || routeInfo.getReturnType().isSpecifiedSingle()) {
+                single = ReactiveExecutionFlow.fromPublisher(Mono.from(Publishers.convertPublisher(body, Publisher.class)));
+            } else {
+                single = ReactiveExecutionFlow.fromPublisher(Flux.from(Publishers.convertPublisher(body, Publisher.class)).collectList());
+            }
+            return single.map((Function<Object, MutableHttpResponse<?>>) o -> {
+                if (!(o instanceof MicronautAwsProxyResponse)) {
+                    ((MutableHttpResponse) containerResponse).body(o);
+                }
+                applyRouteConfig(routeInfo);
+                return containerResponse;
+            });
+        } else {
+            if (!(body instanceof MicronautAwsProxyResponse)) {
+                applyRouteConfig(routeInfo);
+                ((MutableHttpResponse) containerResponse).body(body);
+            }
+            return ExecutionFlow.just(containerResponse);
+        }
+    }
+
+    private void applyRouteConfig(RouteInfo<?> finalRoute) {
+        if (!containerResponse.getContentType().isPresent()) {
+            finalRoute.getAnnotationMetadata().getValue(Produces.class, String.class).ifPresent(containerResponse::contentType);
+        }
+        finalRoute.getAnnotationMetadata().getValue(Status.class, HttpStatus.class).ifPresent(httpStatus -> containerResponse.status(httpStatus));
+    }
+}

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
@@ -59,7 +59,7 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
     private int status;
     private String reason = HttpStatus.OK.getReason();
     private AwsProxyResponse response = new AwsProxyResponse();
-    private final AwsHeaders awsHeaders = new AwsHeaders();
+    private final AwsHeaders awsHeaders;
     private Headers multiValueHeaders = new Headers();
     private Map<String, Cookie> cookies = new ConcurrentHashMap<>(2);
 
@@ -79,6 +79,7 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
         this.handler = environment;
         this.status = HttpStatus.OK.getCode();
         this.response.setStatusCode(HttpStatus.OK.getCode());
+        this.awsHeaders = new AwsHeaders();
     }
 
     @Override
@@ -226,7 +227,7 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
      * An implementation of {@link MutableHttpHeaders} for AWS lambda.
      */
     private class AwsHeaders implements MutableHttpHeaders {
-        private ConversionService conversionService;
+        private ConversionService conversionService = handler.getApplicationContext().getConversionService();
 
         @Override
         public MutableHttpHeaders add(CharSequence header, CharSequence value) {

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautAwsProxyResponse.java
@@ -226,6 +226,7 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
      * An implementation of {@link MutableHttpHeaders} for AWS lambda.
      */
     private class AwsHeaders implements MutableHttpHeaders {
+        private ConversionService conversionService;
 
         @Override
         public MutableHttpHeaders add(CharSequence header, CharSequence value) {
@@ -273,9 +274,14 @@ public class MicronautAwsProxyResponse<T> implements MutableHttpResponse<T>, Clo
         public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
             final String v = get(name);
             if (v != null) {
-                return ConversionService.SHARED.convert(v, conversionContext);
+                return conversionService.convert(v, conversionContext);
             }
             return Optional.empty();
+        }
+
+        @Override
+        public void setConversionService(ConversionService conversionService) {
+            this.conversionService = conversionService;
         }
     }
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -32,69 +32,44 @@ import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.TypeHint;
-import io.micronaut.core.async.publisher.Publishers;
-import io.micronaut.core.async.subscriber.CompletionAwareSubscriber;
 import io.micronaut.core.bind.BeanPropertyBinder;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.convert.value.ConvertibleValues;
 import io.micronaut.core.convert.value.ConvertibleValuesMap;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.type.TypeVariableResolver;
 import io.micronaut.core.util.ArgumentUtils;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.HandlerUtils;
 import io.micronaut.function.aws.LambdaApplicationContextBuilder;
 import io.micronaut.http.HttpAttributes;
-import io.micronaut.http.HttpMethod;
-import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MediaType;
-import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Body;
-import io.micronaut.http.annotation.Consumes;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.Status;
 import io.micronaut.http.bind.RequestBinderRegistry;
-import io.micronaut.http.context.ServerRequestContext;
 import io.micronaut.http.server.HttpServerConfiguration;
 import io.micronaut.http.server.RouteExecutor;
 import io.micronaut.http.server.binding.RequestArgumentSatisfier;
-import io.micronaut.http.server.exceptions.response.ErrorContext;
 import io.micronaut.http.server.exceptions.response.ErrorResponseProcessor;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.jackson.codec.JsonMediaTypeCodec;
 import io.micronaut.scheduling.executor.ExecutorSelector;
-import io.micronaut.web.router.MethodBasedRouteMatch;
 import io.micronaut.web.router.RouteInfo;
-import io.micronaut.web.router.RouteMatch;
 import io.micronaut.web.router.Router;
-import io.micronaut.web.router.UriRouteMatch;
 import io.micronaut.web.router.resource.StaticResourceResolver;
-import org.reactivestreams.Publisher;
-import org.reactivestreams.Subscriber;
-import org.reactivestreams.Subscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import java.io.Closeable;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * Main entry for AWS API proxy with Micronaut.
@@ -134,7 +109,7 @@ public final class MicronautLambdaContainerHandler
     private Router router;
     private ErrorResponseProcessor errorResponseProcessor;
     private RouteExecutor routeExecutor;
-    private final Map<MediaType, BiFunction<Argument<?>, String, Optional<Object>>> mediaTypeBodyDecoder = new HashMap<>();
+    final Map<MediaType, BiFunction<Argument<?>, String, Optional<Object>>> mediaTypeBodyDecoder = new HashMap<>();
 
     /**
      * Default constructor.
@@ -322,79 +297,19 @@ public final class MicronautLambdaContainerHandler
         HandlerUtils.configureWithContext(this, lambdaContext);
 
         try {
-            ServerRequestContext.with(containerRequest, () -> {
-                Optional<UriRouteMatch> routeMatch = containerRequest.getAttribute(HttpAttributes.ROUTE_MATCH, UriRouteMatch.class);
-
-                if (!routeMatch.isPresent()) {
-                    handlePossibleErrorStatus(containerRequest, containerResponse);
-                    return;
-                }
-
-                handleRouteMatch(routeMatch.get(), containerRequest, containerResponse);
-            });
+            new AwsRequestLifecycle(this, routeExecutor, containerRequest, containerResponse).run()
+                .onComplete((r, t) -> {
+                    if (t == null) {
+                        toAwsProxyResponse(containerResponse, r);
+                    } else {
+                        // should never happen, it should be transformed to an error response with onError
+                        LOG.warn("Error in response flow");
+                    }
+                    containerResponse.close();
+                });
         } finally {
             Timer.stop(TIMER_REQUEST);
         }
-    }
-
-    private void handleRouteMatch(
-            RouteMatch<?> originalRoute,
-            MicronautAwsProxyRequest<?> request,
-            MicronautAwsProxyResponse<?> response
-    ) {
-        final AnnotationMetadata annotationMetadata = originalRoute.getAnnotationMetadata();
-        annotationMetadata.stringValue(Produces.class)
-                .map(MediaType::new)
-                .ifPresent(response::contentType);
-
-        Flux<MutableHttpResponse<?>> routeResponse;
-        try {
-            decodeRequestBody(request, originalRoute)
-                .ifPresent(((MicronautAwsProxyRequest) request)::setDecodedBody
-            );
-
-            RouteMatch<?> route = requestArgumentSatisfier.fulfillArgumentRequirements(originalRoute, request, false);
-
-            Flux<RouteMatch<?>> routeMatchPublisher = Flux.just(route);
-
-            routeResponse = routeExecutor.executeRoute(
-                    request,
-                    true,
-                    routeMatchPublisher
-            ).mapNotNull(r -> convertResponseBody(response, r.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).get(), r.body()).block());
-        } catch (Exception e) {
-            routeResponse = Flux.from(routeExecutor.filterPublisher(new AtomicReference<>(request), routeExecutor.onError(e, request)));
-        }
-
-        routeResponse
-                .contextWrite(ctx -> ctx.put(ServerRequestContext.KEY, request))
-                .subscribe(new CompletionAwareSubscriber<HttpResponse<?>>() {
-                    @Override
-                    protected void doOnSubscribe(Subscription subscription) {
-                        subscription.request(1);
-                    }
-
-                    @Override
-                    protected void doOnNext(HttpResponse<?> message) {
-                        toAwsProxyResponse(response, message);
-                        subscription.request(1);
-                    }
-
-                    @Override
-                    protected void doOnError(Throwable throwable) {
-                        try {
-                            final MutableHttpResponse<?> defaultErrorResponse = routeExecutor.createDefaultErrorResponse(request, throwable);
-                            toAwsProxyResponse(response, defaultErrorResponse);
-                        } finally {
-                            response.close();
-                        }
-                    }
-
-                    @Override
-                    protected void doOnComplete() {
-                        response.close();
-                    }
-                });
     }
 
     private MicronautAwsProxyResponse<?> toAwsProxyResponse(
@@ -417,78 +332,6 @@ public final class MicronautLambdaContainerHandler
     private void populateMediaTypeBodyDecoders() {
         mediaTypeBodyDecoder.put(MediaType.APPLICATION_JSON_TYPE, this::getJsonDecodedBody);
         mediaTypeBodyDecoder.put(MediaType.APPLICATION_FORM_URLENCODED_TYPE, this::getFormUrlEncodedDecodedBody);
-    }
-
-    @NonNull
-    private static Optional<String> parseUndecodedBody(@NonNull MicronautAwsProxyRequest<?> containerRequest,
-                                                @NonNull RouteMatch<?> finalRoute,
-                                                @NonNull MediaType mediaType) {
-        if (containerRequest.isBodyDecoded()) {
-            return Optional.empty();
-        }
-        if (!HttpMethod.permitsRequestBody(containerRequest.getMethod())) {
-            return Optional.empty();
-        }
-        final MediaType requestContentType = containerRequest.getContentType().orElse(null);
-        if (requestContentType == null) {
-            return Optional.empty();
-        }
-        if (!mediaType.getExtension().equals(requestContentType.getExtension())) {
-            return Optional.empty();
-        }
-        final MediaType[] expectedContentType = finalRoute.getAnnotationMetadata().getValue(Consumes.class, MediaType[].class).orElse(null);
-        return (expectedContentType == null || Arrays.stream(expectedContentType).anyMatch(ct -> mediaType.getExtension().equals(ct.getExtension()))) ?
-            containerRequest.getBody(String.class) :
-            Optional.empty();
-    }
-
-    @NonNull
-    private Optional<Object> decodeRequestBody(@NonNull MicronautAwsProxyRequest<?> containerRequest,
-                                               @NonNull RouteMatch<?> finalRoute) {
-        return mediaTypeBodyDecoder.entrySet()
-            .stream()
-            .map(e -> decodeRequestBody(containerRequest, finalRoute, e))
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .findFirst();
-    }
-
-    private static Optional<Object> decodeRequestBody(@NonNull MicronautAwsProxyRequest<?> containerRequest,
-                                                      @NonNull RouteMatch<?> finalRoute,
-                                                      @NonNull Map.Entry<MediaType, BiFunction<Argument<?>, String, Optional<Object>>> entry) {
-        return parseUndecodedBody(containerRequest, finalRoute, entry.getKey())
-            .flatMap(body -> decodeRequestBody(body, entry.getValue(), finalRoute));
-    }
-
-    @NonNull
-    private static Optional<Object> decodeRequestBody(@NonNull String body,
-                                               @NonNull BiFunction<Argument<?>, String, Optional<Object>> function,
-                                               @NonNull RouteMatch<?> finalRoute) {
-        if (StringUtils.isNotEmpty(body)) {
-            Argument<?> bodyArgument = parseBodyArgument(finalRoute);
-            return function.apply(bodyArgument, body);
-        }
-        return Optional.empty();
-    }
-
-    @Nullable
-    private static Argument<?> parseBodyArgument(@NonNull RouteMatch<?> finalRoute) {
-        Argument<?> bodyArgument = finalRoute.getBodyArgument().orElse(null);
-        if (bodyArgument == null) {
-            if (finalRoute instanceof MethodBasedRouteMatch) {
-                bodyArgument = Arrays.stream(((MethodBasedRouteMatch) finalRoute).getArguments())
-                    .filter(arg -> HttpRequest.class.isAssignableFrom(arg.getType()))
-                    .findFirst()
-                    .flatMap(TypeVariableResolver::getFirstTypeVariable).orElse(null);
-            }
-        }
-        if (bodyArgument != null) {
-            final Class<?> rawType = bodyArgument.getType();
-            if (Publishers.isConvertibleToPublisher(rawType) || HttpRequest.class.isAssignableFrom(rawType)) {
-                bodyArgument = bodyArgument.getFirstTypeVariable().orElse(Argument.OBJECT_ARGUMENT);
-            }
-        }
-        return bodyArgument;
     }
 
     @NonNull
@@ -565,179 +408,11 @@ public final class MicronautLambdaContainerHandler
         }
     }
 
-    private Mono<MutableHttpResponse<?>> convertResponseBody(
-            MicronautAwsProxyResponse<?> containerResponse,
-            RouteInfo<?> routeInfo,
-            Object body) {
-        if (Publishers.isConvertibleToPublisher(body)) {
-            Mono<?> single;
-            if (Publishers.isSingle(body.getClass()) || routeInfo.getReturnType().isSpecifiedSingle()) {
-                single = Mono.from(Publishers.convertPublisher(body, Publisher.class));
-            } else {
-                single = Flux.from(Publishers.convertPublisher(body, Publisher.class)).collectList();
-            }
-            return single.map((Function<Object, MutableHttpResponse<?>>) o -> {
-                if (!(o instanceof MicronautAwsProxyResponse)) {
-                    ((MutableHttpResponse) containerResponse).body(o);
-                }
-                applyRouteConfig(containerResponse, routeInfo);
-                return containerResponse;
-            });
-        } else {
-            if (!(body instanceof MicronautAwsProxyResponse)) {
-                applyRouteConfig(containerResponse, routeInfo);
-                ((MutableHttpResponse) containerResponse).body(body);
-            }
-            return Mono.just(containerResponse);
-        }
-    }
-
     private void applyRouteConfig(MicronautAwsProxyResponse<?> containerResponse, RouteInfo<?> finalRoute) {
         if (!containerResponse.getContentType().isPresent()) {
             finalRoute.getAnnotationMetadata().getValue(Produces.class, String.class).ifPresent(containerResponse::contentType);
         }
         finalRoute.getAnnotationMetadata().getValue(Status.class, HttpStatus.class).ifPresent(httpStatus -> containerResponse.status(httpStatus));
-    }
-
-    private void handlePossibleErrorStatus(
-            MicronautAwsProxyRequest<?> request,
-            MicronautAwsProxyResponse<?> response) {
-
-        final MediaType contentType = request.getContentType().orElse(null);
-        final String requestMethodName = request.getMethodName();
-
-        // if there is no route present try to locate a route that matches a different HTTP method
-        final List<UriRouteMatch<?, ?>> anyMatchingRoutes = router
-                .findAny(request.getPath(), request)
-                .collect(Collectors.toList());
-        final Collection<MediaType> acceptedTypes = request.accept();
-        final boolean hasAcceptHeader = CollectionUtils.isNotEmpty(acceptedTypes);
-
-        Set<MediaType> acceptableContentTypes = contentType != null ? new HashSet<>(5) : null;
-        Set<String> allowedMethods = new HashSet<>(5);
-        Set<MediaType> produceableContentTypes = hasAcceptHeader ? new HashSet<>(5) : null;
-        for (UriRouteMatch<?, ?> anyRoute : anyMatchingRoutes) {
-            final String routeMethod = anyRoute.getRoute().getHttpMethodName();
-            if (!requestMethodName.equals(routeMethod)) {
-                allowedMethods.add(routeMethod);
-            }
-            if (contentType != null && !anyRoute.doesConsume(contentType)) {
-                acceptableContentTypes.addAll(anyRoute.getRoute().getConsumes());
-            }
-            if (hasAcceptHeader && !anyRoute.doesProduce(acceptedTypes)) {
-                produceableContentTypes.addAll(anyRoute.getRoute().getProduces());
-            }
-        }
-
-        if (CollectionUtils.isNotEmpty(acceptableContentTypes)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Content type not allowed for URI {}, method {}, and content type {}", request.getUri(),
-                        requestMethodName, contentType);
-            }
-
-            handleStatusError(
-                    request,
-                    response,
-                    HttpResponse.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE),
-                    "Content Type [" + contentType + "] not allowed. Allowed types: " + acceptableContentTypes);
-            return;
-        }
-
-        if (CollectionUtils.isNotEmpty(produceableContentTypes)) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Content type not allowed for URI {}, method {}, and content type {}", request.getUri(),
-                        requestMethodName, contentType);
-            }
-
-            handleStatusError(
-                    request,
-                    response,
-                    HttpResponse.status(HttpStatus.NOT_ACCEPTABLE),
-                    "Specified Accept Types " + acceptedTypes + " not supported. Supported types: " + produceableContentTypes);
-            return;
-        }
-
-        if (!allowedMethods.isEmpty()) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Method not allowed for URI {} and method {}", request.getUri(), requestMethodName);
-            }
-
-            handleStatusError(
-                    request,
-                    response,
-                    HttpResponse.notAllowedGeneric(allowedMethods),
-                    "Method [" + requestMethodName + "] not allowed for URI [" + request.getUri() + "]. Allowed methods: " + allowedMethods);
-            return;
-        }
-
-        handleStatusError(
-                request,
-                response,
-                HttpResponse.notFound(),
-                "Page Not Found");
-    }
-
-    private void handleStatusError(
-            MicronautAwsProxyRequest<?> request,
-            MicronautAwsProxyResponse<?> response,
-            MutableHttpResponse<?> defaultResponse,
-            String message) {
-
-        Optional<RouteMatch<Object>> statusRoute = router.findStatusRoute(defaultResponse.status(), request);
-        if (statusRoute.isPresent()) {
-            handleRouteMatch(statusRoute.get(), request, response);
-        } else {
-            if (request.getMethod() != HttpMethod.HEAD) {
-                defaultResponse = errorResponseProcessor.processResponse(
-                        ErrorContext.builder(request).errorMessage(message).build(),
-                        defaultResponse
-                );
-                if (!defaultResponse.getContentType().isPresent()) {
-                    defaultResponse = defaultResponse.contentType(MediaType.APPLICATION_JSON_TYPE);
-                }
-            }
-
-            filterAndEncodeResponse(request, response, Publishers.just(defaultResponse));
-        }
-    }
-
-    private void filterAndEncodeResponse(
-            MicronautAwsProxyRequest<?> request,
-            MicronautAwsProxyResponse<?> response,
-            Publisher<MutableHttpResponse<?>> responsePublisher) {
-        AtomicReference<HttpRequest<?>> requestReference = new AtomicReference<>(request);
-
-        Flux.from(routeExecutor.filterPublisher(requestReference, responsePublisher))
-                .contextWrite(ctx -> ctx.put(ServerRequestContext.KEY, request))
-                .subscribe(new Subscriber<MutableHttpResponse<?>>() {
-                    Subscription subscription;
-                    @Override
-                    public void onSubscribe(Subscription s) {
-                        this.subscription = s;
-                        s.request(1);
-                    }
-
-                    @Override
-                    public void onNext(MutableHttpResponse<?> message) {
-                        toAwsProxyResponse(response, message);
-                        subscription.request(1);
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        try {
-                            final MutableHttpResponse<?> defaultErrorResponse = routeExecutor.createDefaultErrorResponse(request, t);
-                            toAwsProxyResponse(response, defaultErrorResponse);
-                        } finally {
-                            response.close();
-                        }
-                    }
-
-                    @Override
-                    public void onComplete() {
-                        response.close();
-                    }
-                });
     }
 
     @Override

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautRequestReader.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautRequestReader.java
@@ -74,20 +74,6 @@ class MicronautRequestReader extends RequestReader<AwsProxyRequest, MicronautAws
                     config
             );
 
-            List<UriRouteMatch<Object, Object>> uriRoutes = environment.getRouter().findAllClosest(containerRequest);
-
-            if (uriRoutes.isEmpty() && isPreflightRequest(containerRequest)) {
-                List<UriRouteMatch<Object, Object>> anyUriRoutes = environment.getRouter().findAny(containerRequest.getUri().getPath(), containerRequest)
-                    .collect(Collectors.toList());
-                containerRequest.setAttribute(AVAILABLE_HTTP_METHODS, anyUriRoutes.stream().map(UriRouteMatch::getHttpMethod).collect(Collectors.toList()));
-            } else if (!uriRoutes.isEmpty()) {
-                UriRouteMatch<Object, Object> finalRoute = uriRoutes.get(0);
-                final UriRoute route = finalRoute.getRoute();
-                containerRequest.setAttribute(HttpAttributes.ROUTE, route);
-                containerRequest.setAttribute(HttpAttributes.ROUTE_MATCH, finalRoute);
-                containerRequest.setAttribute(HttpAttributes.ROUTE_INFO, finalRoute);
-                containerRequest.setAttribute(HttpAttributes.URI_TEMPLATE, route.getUriMatchTemplate().toString());
-            }
             return containerRequest;
         } catch (Exception e) {
             throw new InvalidRequestEventException("Invalid Request: " + e.getMessage(), e);

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautRequestReader.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautRequestReader.java
@@ -21,21 +21,15 @@ import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.ContainerConfig;
 import com.amazonaws.services.lambda.runtime.Context;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.http.HttpAttributes;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpMethod;
 import io.micronaut.http.HttpRequest;
-import io.micronaut.web.router.UriRoute;
-import io.micronaut.web.router.UriRouteMatch;
 
 import javax.ws.rs.core.SecurityContext;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import static io.micronaut.http.HttpAttributes.AVAILABLE_HTTP_METHODS;
 import static io.micronaut.http.HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD;
 
 /**
@@ -71,8 +65,8 @@ class MicronautRequestReader extends RequestReader<AwsProxyRequest, MicronautAws
                     request,
                     securityContext,
                     lambdaContext,
-                    config
-            );
+                    config,
+                    environment.getApplicationContext().getConversionService());
 
             return containerRequest;
         } catch (Exception e) {

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/VersionSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/VersionSpec.groovy
@@ -25,9 +25,10 @@ class VersionSpec extends Specification {
     MicronautLambdaContainerHandler handler = new MicronautLambdaContainerHandler(
         ApplicationContext.builder().properties([
                 'micronaut.security.enabled': false,
-                'spec.name'                                 : 'VersionSpec',
-                'micronaut.router.versioning.enabled'       : true,
-                'micronaut.router.versioning.header.enabled': true,
+                'spec.name'                                  : 'VersionSpec',
+                'micronaut.router.versioning.enabled'        : true,
+                'micronaut.router.versioning.header.enabled' : true,
+                'micronaut.router.versioning.default-version': '1',
         ])
     )
 

--- a/function-aws-custom-runtime/build.gradle.kts
+++ b/function-aws-custom-runtime/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    annotationProcessor(mn.micronaut.graal)
+    annotationProcessor(libs.micronaut.graal)
     compileOnly(projects.functionAwsApiProxy)
 
     api(mn.micronaut.http.client)

--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
@@ -216,7 +216,7 @@ public abstract class AbstractMicronautLambdaRuntime<RequestType, ResponseType, 
         String handler = getEnv(ReservedRuntimeEnvironmentVariables.HANDLER);
         logn(LogLevel.DEBUG, "Handler: ", handler);
         if (handler != null) {
-            Optional<Class> handlerClassOptional = parseHandlerClass(handler);
+            Optional<Class<?>> handlerClassOptional = parseHandlerClass(handler);
             logn(LogLevel.WARN, "No handler Class parsed for ", handler);
             if (handlerClassOptional.isPresent()) {
                 log(LogLevel.DEBUG, "Handler Class parsed. Instantiating it via introspection\n");
@@ -233,7 +233,7 @@ public abstract class AbstractMicronautLambdaRuntime<RequestType, ResponseType, 
      * @param handler handler in format file.method, where file is the name of the file without an extension, and method is the name of a method or function that's defined in the file.
      * @return Empty or an Optional with the referenced class.
      */
-    protected Optional<Class> parseHandlerClass(@NonNull String handler) {
+    protected Optional<Class<?>> parseHandlerClass(@NonNull String handler) {
         String[] arr = handler.split("::");
         if (arr.length > 0) {
             return ClassUtils.forName(arr[0], null);

--- a/function-aws-test/build.gradle.kts
+++ b/function-aws-test/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation(mn.micronaut.test.junit5)
+    implementation(mnTest.micronaut.test.junit5)
     api(projects.functionAws)
     api(mn.micronaut.function)
     testAnnotationProcessor(mn.micronaut.inject.java)

--- a/function-aws/build.gradle.kts
+++ b/function-aws/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 dependencies {
     api(mn.micronaut.function)
     api(libs.managed.aws.lambda.core)
-    testImplementation(mn.micronaut.mongo.sync)
+    testImplementation(mnMongo.micronaut.mongo.sync)
+    testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.testcontainers.spock)
     testImplementation(libs.testcontainers.mongodb)
     testImplementation(libs.testcontainers)

--- a/function-client-aws/build.gradle.kts
+++ b/function-client-aws/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
     testImplementation(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.http.server.netty)
     testImplementation(mn.micronaut.function.web)
-    testImplementation(mn.micronaut.function.groovy)
-    testImplementation(mn.micronaut.runtime.groovy)
+    testImplementation(mnGroovy.micronaut.function.groovy)
+    testImplementation(mnGroovy.micronaut.runtime.groovy)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ bouncycastle = '1.70'
 fileupload = '0.0.5'
 jetty = '9.4.49.v20220914'
 logback-json-classic = '0.1.5'
+micronaut-discovery = '4.0.0-SNAPSHOT'
 micronaut-graal = '4.0.0-SNAPSHOT'
 micronaut-groovy = '4.0.0-SNAPSHOT'
 micronaut-mongodb = '5.0.0-SNAPSHOT'
@@ -26,7 +27,8 @@ graal = "22.0.0.2"
 
 [libraries]
 
-micronaut-graal = { module = "io.micronaut.graal:micronaut-graal", version.ref = "micronaut-graal" }
+micronaut-discovery-client = { module = "io.micronaut.discovery:micronaut-discovery-client", version.ref = "micronaut-discovery" }
+micronaut-graal = { module = "io.micronaut:micronaut-graal", version.ref = "micronaut-graal" }
 micronaut-groovy = { module = "io.micronaut.groovy:micronaut-groovy-bom", version.ref = "micronaut-groovy" }
 micronaut-mongodb = { module = "io.micronaut.mongodb:micronaut-mongo-bom", version.ref = "micronaut-mongodb" }
 micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,12 @@ bouncycastle = '1.70'
 fileupload = '0.0.5'
 jetty = '9.4.49.v20220914'
 logback-json-classic = '0.1.5'
+micronaut-graal = '4.0.0-SNAPSHOT'
+micronaut-groovy = '4.0.0-SNAPSHOT'
+micronaut-mongodb = '5.0.0-SNAPSHOT'
+micronaut-security = '4.0.0-SNAPSHOT'
+micronaut-serde = '2.0.0-SNAPSHOT'
+micronaut-views = '4.0.0-SNAPSHOT'
 managed-alexa-ask-sdk = "2.44.0"
 managed-aws-java-sdk-v1 = '1.12.332'
 managed-aws-java-sdk-v2 = '2.18.7'
@@ -12,8 +18,20 @@ managed-aws-serverless-core = '1.9'
 managed-aws-cdk-lib='2.50.0'
 servlet-api = "2.5"
 slf4j = "1.7.36"
+testcontainers = "1.17.6"
+
+# The following version should probably
+# be defined in Micronaut Graal but it's not shipped with a BOM yet
+graal = "22.0.0.2"
 
 [libraries]
+
+micronaut-graal = { module = "io.micronaut.graal:micronaut-graal", version.ref = "micronaut-graal" }
+micronaut-groovy = { module = "io.micronaut.groovy:micronaut-groovy-bom", version.ref = "micronaut-groovy" }
+micronaut-mongodb = { module = "io.micronaut.mongodb:micronaut-mongo-bom", version.ref = "micronaut-mongodb" }
+micronaut-serde = { module = "io.micronaut.serde:micronaut-serde-bom", version.ref = "micronaut-serde" }
+micronaut-security = { module = "io.micronaut.security:micronaut-security-bom", version.ref = "micronaut-security" }
+micronaut-views = { module = "io.micronaut.views:micronaut-views-bom", version.ref = "micronaut-views" }
 
 aws-cdk-lib = { module = 'software.amazon.awscdk:aws-cdk-lib', version.ref = 'managed-aws-cdk-lib' }
 
@@ -40,6 +58,7 @@ boms-aws-java-sdk-v2 = { module = 'software.amazon.awssdk:bom', version.ref = 'm
 
 bouncycastle-provider = { module = 'org.bouncycastle:bcprov-jdk15on', version.ref = 'bouncycastle'}
 fileupload = { module = 'org.javadelight:delight-fileupload', version.ref = 'fileupload' }
+graal-sdk = { module = 'org.graalvm.sdk:graal-sdk', version.ref = 'graal' }
 jackson-afterburner = { module = 'com.fasterxml.jackson.module:jackson-module-afterburner' }
 jetty-server = { module = 'org.eclipse.jetty:jetty-server', version.ref = 'jetty' }
 jcl-over-slf4j = { module = 'org.slf4j:jcl-over-slf4j', version.ref = 'slf4j' }
@@ -58,6 +77,7 @@ managed-aws-serverless-core = { module = 'com.amazonaws.serverless:aws-serverles
 managed-jcl-over-slf4j = { module = 'org.slf4j:jcl-over-slf4j', version.ref = 'slf4j' }
 
 servlet-api = { module = 'javax.servlet:servlet-api', version.ref = 'servlet-api' }
+testcontainers-bom = { module = 'org.testcontainers:testcontainers-bom', version.ref = 'testcontainers' }
 testcontainers = { module = 'org.testcontainers:testcontainers' }
 testcontainers-mongodb = { module = 'org.testcontainers:mongodb' }
 testcontainers-spock = { module = 'org.testcontainers:spock' }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "6.0.1"
+    id("io.micronaut.build.shared.settings") version "6.1.1"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
@@ -39,6 +39,11 @@ include("test-suite-kotlin")
 
 configure<io.micronaut.build.MicronautBuildSettingsExtension> {
     importMicronautCatalog()
+    importMicronautCatalog("micronaut-groovy")
+    importMicronautCatalog("micronaut-mongodb")
+    importMicronautCatalog("micronaut-serde")
+    importMicronautCatalog("micronaut-security")
+    importMicronautCatalog("micronaut-views")
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Untested, can't get the snapshot to run locally. Most of the code that I removed seems to be identical with RouteExecutor (or, now, RequestLifecycle), however I may have missed some differences.