### PR TITLE
fix: graal typehint for SingleValueHeaders

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -115,6 +115,7 @@ import java.util.stream.Collectors;
                 ContainerConfig.class,
                 ErrorModel.class,
                 Headers.class,
+                SingleValueHeaders.class,
                 MultiValuedTreeMap.class,
                 AwsProxySecurityContext.class
         }


### PR DESCRIPTION
Native executable was failing in AWS Lambda with:

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.amazonaws.serverless.proxy.model.SingleValueHeaders` (no Creators, like default constructor, exist): no default constructor found
```