### PR TITLE
build: exclude slf4j-api from aws-serverless

### DIFF
--- a/function-aws-api-proxy/build.gradle.kts
+++ b/function-aws-api-proxy/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     implementation(mn.reactor)
     api(mn.micronaut.http.server)
     api(libs.managed.aws.serverless.core) {
+        exclude(group = "org.slf4j", module = "slf4j-api")
         exclude(group = "javax.servlet", module = "javax.servlet-api")
         exclude(group = "com.fasterxml.jackson.module", module = "jackson-module-afterburner")
         exclude(group = "commons-logging")


### PR DESCRIPTION
exclude `slf4j-api` from `com.amazonaws.serverless:aws-serverless-java-container-core`

Since version `1.9` it was pulling` slf4j-api` `2.0.6`

Close https://github.com/micronaut-projects/micronaut-aws/issues/1560