### PR TITLE
Support multiple prefixes for aws distributed configuration 

### DIFF
--- a/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfiguration.java
+++ b/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfiguration.java
@@ -17,6 +17,7 @@ package io.micronaut.aws.distributedconfiguration;
 
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
+import java.util.List;
 
 /**
  * Configuration for Distributed Configuration using AWS services such as AWS Parameter Store or Secrets Manager.
@@ -33,6 +34,13 @@ public interface AwsDistributedConfiguration {
      */
     @NonNull
     String getPrefix();
+
+    /**
+     * @return List of prefixes for AWS Distributed Configuration resources names. If it is non-empty,
+     * {@link AwsDistributedConfiguration#getPrefix()} is not used
+     */
+    @NonNull
+    List<String> getPrefixes();
 
     /**
      * Delimiter after prefix and application name. For /config/application_dev/micronaut.security.oauth2.clients.mycompanyauth.client-secret

--- a/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfiguration.java
+++ b/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfiguration.java
@@ -19,6 +19,8 @@ import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+
 /**
  * Configuration for Distributed Configuration using AWS services such as AWS Parameter Store or Secrets Manager.
  *
@@ -30,17 +32,23 @@ public interface AwsDistributedConfiguration {
 
     /**
      *
-     * @return Prefix for AWS Distributed Configuration resources names. For example `/config/`
+     * @return Prefix for AWS Distributed Configuration resources names. For example `/config/`.
+     * If {@link AwsDistributedConfiguration#getPrefixes()} returns non-empty list, this value is
+     * ignored.
      */
     @NonNull
     String getPrefix();
 
     /**
      * @return List of prefixes for AWS Distributed Configuration resources names. If it is non-empty,
-     * {@link AwsDistributedConfiguration#getPrefix()} is not used
+     * {@link AwsDistributedConfiguration#getPrefix()} is not used.
+     *
+     * @since 3.12.1
      */
     @NonNull
-    List<String> getPrefixes();
+    default List<String> getPrefixes() {
+        return emptyList();
+    }
 
     /**
      * Delimiter after prefix and application name. For /config/application_dev/micronaut.security.oauth2.clients.mycompanyauth.client-secret

--- a/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfigurationProperties.java
+++ b/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfigurationProperties.java
@@ -53,6 +53,7 @@ public class AwsDistributedConfigurationProperties implements AwsDistributedConf
     @NonNull
     String prefix = DEFAULT_PREFIX;
 
+    @NonNull
     private List<String> prefixes = new ArrayList<>();
 
     @NonNull

--- a/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfigurationProperties.java
+++ b/aws-distributed-configuration/src/main/java/io/micronaut/aws/distributedconfiguration/AwsDistributedConfigurationProperties.java
@@ -20,6 +20,8 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.NonNull;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link AwsDistributedConfiguration}.
@@ -50,6 +52,8 @@ public class AwsDistributedConfigurationProperties implements AwsDistributedConf
 
     @NonNull
     String prefix = DEFAULT_PREFIX;
+
+    private List<String> prefixes = new ArrayList<>();
 
     @NonNull
     private String commonApplicationName = DEFAULT_COMMON_APPLICATION_NAME;
@@ -105,6 +109,16 @@ public class AwsDistributedConfigurationProperties implements AwsDistributedConf
      */
     public void setSearchCommonApplication(boolean searchCommonApplication) {
         this.searchCommonApplication = searchCommonApplication;
+    }
+
+    @Override
+    @NonNull
+    public List<String> getPrefixes() {
+        return prefixes;
+    }
+
+    public void setPrefixes(@NonNull List<String> prefixes) {
+        this.prefixes = prefixes;
     }
 
     @Override


### PR DESCRIPTION
I would like to suggest an addition to support multiple prefixes for micronaut AWS distributed configuration. The change is not breaking and the previous remains the same if the prefixes property is not set. 

The need it fulfills is the situation where the configuration has to be read from multiple secrets that do not share a common prefix. 

Let me know what you think.