### PR TITLE
Fix for drive-by localhost cors deny TCK test

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MicronautLambdaContainerHandler.java
@@ -364,7 +364,10 @@ public final class MicronautLambdaContainerHandler
                     request,
                     true,
                     routeMatchPublisher
-            ).mapNotNull(r -> convertResponseBody(response, r.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class).get(), r.body()).block());
+            ).mapNotNull(r -> r.getAttribute(HttpAttributes.ROUTE_INFO, RouteInfo.class)
+                .map(routeInfo -> convertResponseBody(response, routeInfo, r.body()).block())
+                .orElseGet(() -> (MutableHttpResponse) response)
+            );
         } catch (Exception e) {
             routeResponse = Flux.from(routeExecutor.filterPublisher(new AtomicReference<>(request), routeExecutor.onError(e, request)));
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "3.8.0"
+micronaut = "3.8.3"
 micronaut-docs = "2.0.0"
 micronaut-test = "3.8.0"
 groovy = "3.0.13"

--- a/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -9,6 +9,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Proxy")
-@ExcludeClassNamePatterns(value = "io.micronaut.http.server.tck.tests.RemoteAddressTest|io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest|io.micronaut.http.server.tck.tests.BodyTest|io.micronaut.http.server.tck.tests.cors.SimpleRequestWithCorsNotEnabledTest")
+@ExcludeClassNamePatterns(value = "io.micronaut.http.server.tck.tests.RemoteAddressTest|io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest|io.micronaut.http.server.tck.tests.BodyTest")
 public class MicronautLambdaHandlerHttpServerTestSuite {
 }


### PR DESCRIPTION
When the filter blocks access to localhost from a non-local origin, there is no ROUTE_INFO set on the response object.

Previously, we just called get() on the Optional.  This fails.

I believe the fix is to only continue processing the response if the ROUTE_INFO has been applied to the response.