### PR TITLE
Fix the Octet test

### DIFF
--- a/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/LambdaServerUnderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/LambdaServerUnderTest.java
@@ -27,6 +27,7 @@ import io.micronaut.http.simple.SimpleHttpResponseFactory;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +114,11 @@ public class LambdaServerUnderTest implements ServerUnderTest {
                 }
             }
         }
-        response.body(awsProxyResponse.getBody());
+        if (awsProxyResponse.isBase64Encoded()) {
+            response.body(Base64.getMimeDecoder().decode(awsProxyResponse.getBody()));
+        } else {
+            response.body(awsProxyResponse.getBody());
+        }
 
         if (response.getStatus().getCode() >= 400) {
             throw new HttpClientResponseException("error", response);

--- a/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -1,7 +1,6 @@
 package io.micronaut.http.server.tck.lambda.tests;
 
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
-import org.junit.platform.suite.api.IncludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
@@ -9,10 +8,9 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Proxy")
-@ExcludeClassNamePatterns(value = {
+@ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.RemoteAddressTest", // CaptureRemoteAddressFiter throws NPE getting the address
     "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
-    "io.micronaut.http.server.tck.tests.OctetTest",
     "io.micronaut.http.server.tck.tests.filter.RequestFilterExceptionHandlerTest",
     "io.micronaut.http.server.tck.tests.filter.ClientRequestFilterTest",
     "|io.micronaut.http.server.tck.tests.ErrorHandlerTest", // 2 tests Fail as CORs headers are not added to the response after deserialization fails
@@ -20,8 +18,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.BodyTest", // Fails with a multi-value publisher as the body type
     "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest", // Fails as port cannot be resolved
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest"
-}
-
-)
+})
 public class MicronautLambdaHandlerHttpServerTestSuite {
 }


### PR DESCRIPTION
We need to decode base64 responses in the test harness