### PR TITLE
test: Fix the RemoteAddressTest in the TCK by providing a resolved IP address

### DIFF
--- a/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/LambdaServerUnderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/LambdaServerUnderTest.java
@@ -2,6 +2,7 @@ package io.micronaut.http.server.tck.lambda;
 
 import com.amazonaws.serverless.exceptions.ContainerInitializationException;
 import com.amazonaws.serverless.proxy.internal.testutils.MockLambdaContext;
+import com.amazonaws.serverless.proxy.model.ApiGatewayRequestIdentity;
 import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
 import com.amazonaws.serverless.proxy.model.AwsProxyRequestContext;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
@@ -63,7 +64,15 @@ public class LambdaServerUnderTest implements ServerUnderTest {
         AwsProxyRequest input = new AwsProxyRequest();
         input.setHttpMethod(request.getMethodName());
         input.setRequestContext(new AwsProxyRequestContext() {
-
+            @Override
+            public ApiGatewayRequestIdentity getIdentity() {
+                return new ApiGatewayRequestIdentity() {
+                    @Override
+                    public String getSourceIp() {
+                        return "127.0.0.1";
+                    }
+                };
+            }
         });
         input.setPath(request.getPath());
         for (String headerName : request.getHeaders().names()) {

--- a/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -9,7 +9,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Proxy")
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.RemoteAddressTest", // CaptureRemoteAddressFiter throws NPE getting the address
     "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
     "io.micronaut.http.server.tck.tests.filter.RequestFilterExceptionHandlerTest",
     "io.micronaut.http.server.tck.tests.filter.ClientRequestFilterTest",


### PR DESCRIPTION
The test gets the IP address, and this is null if the InetAddress is unresolveable