### PR TITLE
TCK: Add a mutable version of MicronautAwsProxyRequest

### DIFF
--- a/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -10,11 +10,8 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Proxy")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.RemoteAddressTest", // CaptureRemoteAddressFiter throws NPE getting the address
-    "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
-    "io.micronaut.http.server.tck.tests.filter.RequestFilterExceptionHandlerTest",
     "io.micronaut.http.server.tck.tests.filter.ClientRequestFilterTest",
     "|io.micronaut.http.server.tck.tests.ErrorHandlerTest", // 2 tests Fail as CORs headers are not added to the response after deserialization fails
-    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest",
     "io.micronaut.http.server.tck.tests.BodyTest", // Fails with a multi-value publisher as the body type
     "io.micronaut.http.server.tck.tests.filter.ClientResponseFilterTest"
 })


### PR DESCRIPTION
This allows the client filter TCK tests that mutate the request to pass.

The Cookies were effectively mutable already (as they were simple cookies)

To make parameters and headers mutable, I updated the Aws variants