### PR TITLE
#1687 Fix native image build with CloudWatchLoggingAppender

### DIFF
--- a/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
+++ b/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.aws.cloudwatch.logging
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.PatternLayout
+import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder
 import io.micronaut.discovery.ServiceInstance
@@ -64,6 +65,7 @@ class CloudWatchLoggingAppenderSpec extends Specification {
     void 'test error queue size equal to 0'() {
         when:
         appender.queueSize = 0
+        appender.dispatchOnStart = true
         appender.start()
 
         then:
@@ -75,6 +77,7 @@ class CloudWatchLoggingAppenderSpec extends Specification {
         when:
         appender.queueSize = 100
         appender.publishPeriod = 0
+        appender.dispatchOnStart = true
         appender.start()
 
         then:
@@ -85,6 +88,7 @@ class CloudWatchLoggingAppenderSpec extends Specification {
     void 'test error max batch size less or equal to 0'() {
         when:
         appender.maxBatchSize = 0
+        appender.dispatchOnStart = true
         appender.start()
 
         then:
@@ -97,6 +101,7 @@ class CloudWatchLoggingAppenderSpec extends Specification {
         appender.queueSize = 100
         appender.publishPeriod = 100
         appender.encoder = null
+        appender.dispatchOnStart = true
         appender.start()
 
         then:
@@ -167,6 +172,49 @@ class CloudWatchLoggingAppenderSpec extends Specification {
         thrown(UnsupportedOperationException)
     }
 
+    void 'test start dispatch on start'() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, "testMessage", System.currentTimeMillis())
+
+        when:
+        appender.dispatchOnStart = true
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            cloudWatchLogsClient.putLogsRequestList.size() == 1
+        }
+        cloudWatchLogsClient.putLogsRequestList.get(0).logEvents()[0].message().contains("testMessage")
+    }
+
+    void 'test start dispatch on append'() {
+        given:
+        PollingConditions conditions = new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25)
+        LoggingEvent event = createEvent("name", Level.INFO, "testMessage", System.currentTimeMillis())
+
+        when:
+        appender.groupName = "testGroup"
+        appender.streamName = "testStream"
+        appender.start()
+
+        then:
+        conditions.within(1) {
+            cloudWatchLogsClient.putLogsRequestList.size() == 0
+        }
+
+        when:
+        appender.doAppend(event)
+
+        then:
+        conditions.eventually {
+            cloudWatchLogsClient.putLogsRequestList.size() == 1
+        }
+        cloudWatchLogsClient.putLogsRequestList.get(0).logEvents()[0].message().contains("testMessage")
+        cloudWatchLogsClient.putLogsRequestList.get(0).logStreamName() == "testStream"
+    }
+
     void 'custom groupName and StreamName'() {
         given:
         def testGroup = "testGroup"
@@ -178,6 +226,7 @@ class CloudWatchLoggingAppenderSpec extends Specification {
         when:
         appender.groupName = testGroup
         appender.streamName = testStream
+        appender.dispatchOnStart = true
         appender.start()
         appender.doAppend(event)
 


### PR DESCRIPTION
- Postpone the dispatch thread creation to runtime. Start the thread to send logs to cloudwatch only when `append` method is called, instead of `start`. This way the thread is not started during build time, which is unsupported by native image. (See #1687 for details).
- Create `dispatchOnStart` property to return to previous behavior if needed.