### PR TITLE
fix: closing static logging client

### DIFF
--- a/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
+++ b/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
@@ -75,7 +75,9 @@ final class CloudWatchLoggingClient implements ApplicationEventListener<ServerSt
     }
 
     static synchronized void destroy() {
-        CloudWatchLoggingClient.logging.close();
+        if (CloudWatchLoggingClient.logging != null) {
+            CloudWatchLoggingClient.logging.close();
+        }
         CloudWatchLoggingClient.logging = null;
         CloudWatchLoggingClient.host = null;
         CloudWatchLoggingClient.appName = null;


### PR DESCRIPTION
When the cloudwatch logs client bean is getting destroyed, it can throw NPE. If there is no cw logs appender used.

Added null check before closing to eliminate case of NPE, for use-case CW Logs Client is used apart from logging use-cases.