### PR TITLE
Exclude module as well as just group

### DIFF
--- a/aws-cloudwatch-logging/build.gradle.kts
+++ b/aws-cloudwatch-logging/build.gradle.kts
@@ -9,7 +9,8 @@ dependencies {
 
     implementation(mnLogging.logback.classic)
     implementation(libs.logback.json.classic) {
-        exclude(group = "ch.qos.logback")
+        // Exclude group and module for the POM
+        exclude(group = "ch.qos.logback", module = "logback-classic")
     }
 
     testRuntimeOnly(mn.snakeyaml)


### PR DESCRIPTION
When we exclude a dependency, this will end up in the POM.

For Maven to consume this, we should specify both the group and module.

This then ends up in the POM as

```
    <dependency>
      <groupId>ch.qos.logback.contrib</groupId>
      <artifactId>logback-json-classic</artifactId>
      <version>0.1.5</version>
      <scope>runtime</scope>
      <exclusions>
        <exclusion>
          <artifactId>logback-classic</artifactId>
          <groupId>ch.qos.logback</groupId>
        </exclusion>
      </exclusions>
    </dependency>
```