### PR TITLE
graal: more TypeHint.AccessTypes for Lambda Events

### DIFF
--- a/function-aws-custom-runtime/build.gradle.kts
+++ b/function-aws-custom-runtime/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    annotationProcessor(mn.micronaut.graal)
     compileOnly(projects.micronautFunctionAwsApiProxy)
     api(libs.managed.aws.lambda.events)
     api(projects.micronautAwsUa)

--- a/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
+++ b/function-aws-custom-runtime/src/main/java/io/micronaut/function/aws/runtime/AbstractMicronautLambdaRuntime.java
@@ -64,6 +64,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Predicate;
+
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_DECLARED_CONSTRUCTORS;
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_DECLARED_FIELDS;
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_DECLARED_METHODS;
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_PUBLIC;
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_PUBLIC_CONSTRUCTORS;
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_PUBLIC_FIELDS;
+import static io.micronaut.core.annotation.TypeHint.AccessType.ALL_PUBLIC_METHODS;
 import static io.micronaut.http.HttpHeaders.USER_AGENT;
 
 /**
@@ -79,7 +87,15 @@ import static io.micronaut.http.HttpHeaders.USER_AGENT;
  * @since 2.0.0
  */
 @TypeHint(
-        accessType = {TypeHint.AccessType.ALL_DECLARED_CONSTRUCTORS, TypeHint.AccessType.ALL_PUBLIC},
+        accessType = {
+            ALL_PUBLIC,
+            ALL_DECLARED_CONSTRUCTORS,
+            ALL_PUBLIC_CONSTRUCTORS,
+            ALL_DECLARED_METHODS,
+            ALL_DECLARED_FIELDS,
+            ALL_PUBLIC_METHODS,
+            ALL_PUBLIC_FIELDS
+        },
         value = {
                 com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.class,
                 com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.ProxyRequestContext.class,


### PR DESCRIPTION
To solve errors when deploying a GraalVM Native Image with jackson databind to a Lambda custom runtime. 

```
io.micronaut.http.client.exceptions.HttpClientResponseException: 
Error decoding HTTP response body: 
    Error decoding JSON stream for type [APIGatewayProxyRequestEvent]: 
Cannot construct instance of `com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent`: 
  cannot deserialize from Object value (no delegate- or property-based Creator): this appears to be a native image, in which case you may need to configure reflection for the class that is to be deserialized

```