### PR TITLE
feat: Add CustomPojoSerializer

### DIFF
--- a/aws-lambda-events-serde/build.gradle.kts
+++ b/aws-lambda-events-serde/build.gradle.kts
@@ -4,10 +4,10 @@ plugins {
 
 dependencies {
     annotationProcessor(mnSerde.micronaut.serde.processor)
-    implementation(mnSerde.micronaut.serde.jackson)
-    implementation(libs.managed.aws.lambda.events)
-    testImplementation(libs.assertj.core)
+    api(libs.managed.aws.lambda.events)
+    api(mnSerde.micronaut.serde.jackson)
     implementation(libs.managed.aws.lambda.java.serialization)
+    testImplementation(libs.assertj.core)
 }
 
 micronautBuild {

--- a/function-aws/build.gradle.kts
+++ b/function-aws/build.gradle.kts
@@ -5,10 +5,11 @@ plugins {
 dependencies {
     api(mn.micronaut.function)
     api(libs.managed.aws.lambda.core)
+    implementation(mn.micronaut.json.core)
     testImplementation(mnMongo.micronaut.mongo.sync)
     testImplementation(platform(libs.testcontainers.bom))
     testImplementation(libs.testcontainers.spock)
     testImplementation(libs.testcontainers.mongodb)
     testImplementation(libs.testcontainers)
-    testRuntimeOnly(mn.micronaut.jackson.databind)
+    testImplementation(projects.micronautAwsLambdaEventsSerde)
 }

--- a/function-aws/src/main/java/io/micronaut/function/aws/CustomPojoSerializerException.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/CustomPojoSerializerException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import java.io.IOException;
+
+/**
+ * Exception raised when serialization with {@link JsonMapperCustomPojoSerializer} fails.
+ * @author Sergio del Amo
+ * @since 4.0.0
+ */
+public class CustomPojoSerializerException extends RuntimeException {
+    public CustomPojoSerializerException(IOException e) {
+        super(e);
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws;
+
+import com.amazonaws.services.lambda.runtime.CustomPojoSerializer;
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Type;
+
+/**
+ * Provides an implementation of {@link CustomPojoSerializer} which is loaded via SPI. This implementation avoids paying a double hit on performance when using a serialization library inside the Lambda function.
+ * @author Sergio del Amo
+ * @since 4.0.0
+ */
+public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
+    private JsonMapper jsonMapper;
+
+    public JsonMapperCustomPojoSerializer() {
+        this.jsonMapper = JsonMapper.createDefault();
+    }
+
+    @Override
+    public <T> T fromJson(InputStream input, Type type) {
+        try {
+            return (T) jsonMapper.readValue(input, Argument.of(type));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> T fromJson(String input, Type type) {
+        try {
+            return (T) jsonMapper.readValue(input, Argument.of(type));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> void toJson(T value, OutputStream output, Type type) {
+        Argument<T> argumentType = (Argument<T>) Argument.of(type);
+        try {
+            jsonMapper.writeValue(output, argumentType, value);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
@@ -41,7 +41,7 @@ public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
         try {
             return (T) jsonMapper.readValue(input, Argument.of(type));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new CustomPojoSerializerException(e);
         }
     }
 
@@ -50,7 +50,7 @@ public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
         try {
             return (T) jsonMapper.readValue(input, Argument.of(type));
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new CustomPojoSerializerException(e);
         }
     }
 
@@ -60,7 +60,7 @@ public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
         try {
             jsonMapper.writeValue(output, argumentType, value);
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new CustomPojoSerializerException(e);
         }
     }
 }

--- a/function-aws/src/main/resources/META-INF/services/com.amazonaws.services.lambda.runtime.CustomPojoSerializer
+++ b/function-aws/src/main/resources/META-INF/services/com.amazonaws.services.lambda.runtime.CustomPojoSerializer
@@ -1,0 +1,1 @@
+io.micronaut.function.aws.JsonMapperCustomPojoSerializer

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/JsonMapperCustomPojoSerializerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/JsonMapperCustomPojoSerializerSpec.groovy
@@ -1,0 +1,128 @@
+package io.micronaut.function.aws
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.CustomPojoSerializer
+import io.micronaut.serde.annotation.Serdeable
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+class JsonMapperCustomPojoSerializerSpec extends Specification {
+
+    void "via SPI you can load JsonMapperCustomPojoSerializer as CustomPojoSerializer"() {
+        given:
+        File f = new File("src/test/resources/api-gateway-proxy.json")
+
+        expect:
+        f.exists()
+
+        when:
+        ServiceLoader<CustomPojoSerializer> loader = ServiceLoader.load(CustomPojoSerializer.class);
+        Iterator<CustomPojoSerializer> iterator = loader.iterator();
+
+        then:
+        iterator.hasNext()
+
+        when:
+        CustomPojoSerializer customPojoSerializer = iterator.next()
+
+        then:
+        customPojoSerializer instanceof JsonMapperCustomPojoSerializer
+
+        when:
+        APIGatewayProxyRequestEvent event = customPojoSerializer.fromJson(f.newInputStream(), APIGatewayProxyRequestEvent.class)
+
+        then:
+        assertApiGatewayProxyRequestEvent(event)
+
+        when:
+        event = customPojoSerializer.fromJson(f.text, APIGatewayProxyRequestEvent.class)
+
+        then:
+        assertApiGatewayProxyRequestEvent(event)
+
+        when:
+        ByteArrayOutputStream baos = new ByteArrayOutputStream()
+        customPojoSerializer.toJson(new Book(title: "Building Microservices"), baos, Book.class)
+
+        then:
+        '{"title":"Building Microservices"}' == new String(baos.toByteArray(), StandardCharsets.UTF_8)
+    }
+
+    @Serdeable
+    static class Book {
+        String title
+    }
+
+    void assertApiGatewayProxyRequestEvent(APIGatewayProxyRequestEvent event) {
+        assert "eyJ0ZXN0IjoiYm9keSJ9" == event.body
+        assert "/{proxy+}" == event.resource
+        assert "/path/to/resource" == event.path
+        assert "POST" == event.httpMethod
+        assert event.isBase64Encoded
+        assert [foo: "bar"] == event.queryStringParameters
+        assert [foo: ["bar"]] == event.multiValueQueryStringParameters
+        assert [proxy: "/path/to/resource"] == event.pathParameters
+        assert [baz: "qux"] == event.stageVariables
+        assert [
+                "Accept"                      : "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+                "Accept-Encoding"             : "gzip, deflate, sdch",
+                "Accept-Language"             : "en-US,en;q=0.8",
+                "Cache-Control"               : "max-age=0",
+                "CloudFront-Forwarded-Proto"  : "https",
+                "CloudFront-Is-Desktop-Viewer": "true",
+                "CloudFront-Is-Mobile-Viewer" : "false",
+                "CloudFront-Is-SmartTV-Viewer": "false",
+                "CloudFront-Is-Tablet-Viewer" : "false",
+                "CloudFront-Viewer-Country"   : "US",
+                "Host"                        : "1234567890.execute-api.us-east-1.amazonaws.com",
+                "Upgrade-Insecure-Requests"   : "1",
+                "User-Agent"                  : "Custom User Agent String",
+                "Via"                         : "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+                "X-Amz-Cf-Id"                 : "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+                "X-Forwarded-For"             : "127.0.0.1, 127.0.0.2",
+                "X-Forwarded-Port"            : "443",
+                "X-Forwarded-Proto"           : "https"
+        ] == event.headers
+        assert ["text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"] == event.multiValueHeaders.get("Accept")
+        assert ["gzip, deflate, sdch"] == event.multiValueHeaders.get("Accept-Encoding")
+        assert ["en-US,en;q=0.8"] == event.multiValueHeaders.get("Accept-Language")
+        assert ["max-age=0"] == event.multiValueHeaders.get("Cache-Control")
+        assert ["https"] == event.multiValueHeaders.get("CloudFront-Forwarded-Proto")
+        assert ["true"] == event.multiValueHeaders.get("CloudFront-Is-Desktop-Viewer")
+        assert ["false"] == event.multiValueHeaders.get("CloudFront-Is-Mobile-Viewer")
+        assert ["false"] == event.multiValueHeaders.get("CloudFront-Is-SmartTV-Viewer")
+        assert ["false"] == event.multiValueHeaders.get("CloudFront-Is-Tablet-Viewer")
+        assert ["US"] == event.multiValueHeaders.get("CloudFront-Viewer-Country")
+        assert ["0123456789.execute-api.us-east-1.amazonaws.com"] == event.multiValueHeaders.get("Host")
+        assert ["1"] == event.multiValueHeaders.get("Upgrade-Insecure-Requests")
+        assert ["Custom User Agent String"] == event.multiValueHeaders.get("User-Agent")
+        assert ["1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)"] == event.multiValueHeaders.get("Via")
+        assert ["cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA=="] == event.multiValueHeaders.get("X-Amz-Cf-Id")
+        assert ["127.0.0.1, 127.0.0.2"] == event.multiValueHeaders.get("X-Forwarded-For")
+        assert ["443"] == event.multiValueHeaders.get("X-Forwarded-Port")
+        assert ["https"] == event.multiValueHeaders.get("X-Forwarded-Proto")
+        assert "123456789012" == event.requestContext.accountId
+        assert "123456" == event.requestContext.resourceId
+        assert "prod" == event.requestContext.stage
+        assert "c6af9ac6-7b61-11e6-9a41-93e8deadbeef" == event.requestContext.requestId
+        //assert "09/Apr/2015:12:34:56 +0000" == event.requestContext.requestTime
+        //assert 1428582896000 == event.requestContext.requestTimeEpoch
+        assert null == event.requestContext.identity.cognitoIdentityPoolId
+        assert null == event.requestContext.identity.accountId
+        assert null == event.requestContext.identity.cognitoIdentityId
+        assert null == event.requestContext.identity.caller
+        assert null == event.requestContext.identity.accessKey
+        assert "127.0.0.1" == event.requestContext.identity.sourceIp
+        assert null == event.requestContext.identity.cognitoAuthenticationType
+        assert null == event.requestContext.identity.cognitoAuthenticationProvider
+        assert null == event.requestContext.identity.userArn
+        assert "Custom User Agent String" == event.requestContext.identity.userAgent
+        assert null == event.requestContext.identity.user
+        assert "/prod/path/to/resource" == event.requestContext.path
+        assert "/{proxy+}" == event.requestContext.resourcePath
+        assert "POST" == event.requestContext.httpMethod
+        assert "1234567890" == event.requestContext.apiId
+        //assert "HTTP/1.1" == event.requestContext.protocol
+    }
+}

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestHandlerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestHandlerSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.function.aws
 import com.amazonaws.services.lambda.runtime.Context
 import groovy.transform.Canonical
 import io.micronaut.context.env.Environment
+import io.micronaut.serde.annotation.Serdeable
 import spock.lang.Specification
 
 import jakarta.inject.Inject
@@ -72,6 +73,7 @@ class MicronautRequestHandlerSpec extends Specification {
         }
     }
 
+    @Serdeable
     @Canonical
     static class Point {
         Integer x,y

--- a/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestStreamHandlerSpec.groovy
+++ b/function-aws/src/test/groovy/io/micronaut/function/aws/MicronautRequestStreamHandlerSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.function.aws
 import com.amazonaws.services.lambda.runtime.Context
 import io.micronaut.context.env.Environment
 import io.micronaut.function.FunctionBean
+import io.micronaut.serde.annotation.Serdeable
 import spock.lang.Specification
 
 import java.util.function.Function
@@ -92,6 +93,7 @@ class MicronautRequestStreamHandlerSpec extends Specification{
         output.toString() == 'value 20'
     }
 
+    @Serdeable
     static class Book {
         String title
     }

--- a/function-aws/src/test/resources/api-gateway-proxy.json
+++ b/function-aws/src/test/resources/api-gateway-proxy.json
@@ -1,0 +1,123 @@
+{
+  "body": "eyJ0ZXN0IjoiYm9keSJ9",
+  "resource": "/{proxy+}",
+  "path": "/path/to/resource",
+  "httpMethod": "POST",
+  "isBase64Encoded": true,
+  "queryStringParameters": {
+    "foo": "bar"
+  },
+  "multiValueQueryStringParameters": {
+    "foo": [
+      "bar"
+    ]
+  },
+  "pathParameters": {
+    "proxy": "/path/to/resource"
+  },
+  "stageVariables": {
+    "baz": "qux"
+  },
+  "headers": {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+    "Accept-Encoding": "gzip, deflate, sdch",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Cache-Control": "max-age=0",
+    "CloudFront-Forwarded-Proto": "https",
+    "CloudFront-Is-Desktop-Viewer": "true",
+    "CloudFront-Is-Mobile-Viewer": "false",
+    "CloudFront-Is-SmartTV-Viewer": "false",
+    "CloudFront-Is-Tablet-Viewer": "false",
+    "CloudFront-Viewer-Country": "US",
+    "Host": "1234567890.execute-api.us-east-1.amazonaws.com",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "Custom User Agent String",
+    "Via": "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)",
+    "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
+    "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
+    "X-Forwarded-Port": "443",
+    "X-Forwarded-Proto": "https"
+  },
+  "multiValueHeaders": {
+    "Accept": [
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+    ],
+    "Accept-Encoding": [
+      "gzip, deflate, sdch"
+    ],
+    "Accept-Language": [
+      "en-US,en;q=0.8"
+    ],
+    "Cache-Control": [
+      "max-age=0"
+    ],
+    "CloudFront-Forwarded-Proto": [
+      "https"
+    ],
+    "CloudFront-Is-Desktop-Viewer": [
+      "true"
+    ],
+    "CloudFront-Is-Mobile-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-SmartTV-Viewer": [
+      "false"
+    ],
+    "CloudFront-Is-Tablet-Viewer": [
+      "false"
+    ],
+    "CloudFront-Viewer-Country": [
+      "US"
+    ],
+    "Host": [
+      "0123456789.execute-api.us-east-1.amazonaws.com"
+    ],
+    "Upgrade-Insecure-Requests": [
+      "1"
+    ],
+    "User-Agent": [
+      "Custom User Agent String"
+    ],
+    "Via": [
+      "1.1 08f323deadbeefa7af34d5feb414ce27.cloudfront.net (CloudFront)"
+    ],
+    "X-Amz-Cf-Id": [
+      "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA=="
+    ],
+    "X-Forwarded-For": [
+      "127.0.0.1, 127.0.0.2"
+    ],
+    "X-Forwarded-Port": [
+      "443"
+    ],
+    "X-Forwarded-Proto": [
+      "https"
+    ]
+  },
+  "requestContext": {
+    "accountId": "123456789012",
+    "resourceId": "123456",
+    "stage": "prod",
+    "requestId": "c6af9ac6-7b61-11e6-9a41-93e8deadbeef",
+    "requestTime": "09/Apr/2015:12:34:56 +0000",
+    "requestTimeEpoch": 1428582896000,
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "accountId": null,
+      "cognitoIdentityId": null,
+      "caller": null,
+      "accessKey": null,
+      "sourceIp": "127.0.0.1",
+      "cognitoAuthenticationType": null,
+      "cognitoAuthenticationProvider": null,
+      "userArn": null,
+      "userAgent": "Custom User Agent String",
+      "user": null
+    },
+    "path": "/prod/path/to/resource",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "POST",
+    "apiId": "1234567890",
+    "protocol": "HTTP/1.1"
+  }
+}

--- a/src/main/docs/guide/lambda/customPojoSerialization.adoc
+++ b/src/main/docs/guide/lambda/customPojoSerialization.adoc
@@ -1,0 +1,9 @@
+`micronaut-function-aws` provides an implementation of `com.amazonaws.services.lambda.runtime.CustomPojoSerializer` which is loaded via SPI. This `CustomPojoSerialization` avoids your Micronaut function to pay a double hit on performances when using a serialization library inside the Lambda function.
+
+You need to add a dependency to either https://micronaut-projects.github.io/micronaut-serialization/latest/guide[Micronaut Serialization]
+
+dependency:micronaut-serde-jackson[groupId="io.micronaut.serde"]
+
+or to Micronaut Jackson Databind:
+
+dependency:micronaut-jackson-databind[groupId="io.micronaut"]

--- a/src/main/docs/guide/mnawsfour.adoc
+++ b/src/main/docs/guide/mnawsfour.adoc
@@ -3,3 +3,4 @@
 * `micronaut-function-aws-api-proxy` modules supports both Payload format version v1 and v2. For functions of type `Application`, use the handler api:function.aws.proxy.payload1.ApiGatewayProxyRequestEventFunction[] for https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format[Payload format version 1.0] and
 api:function.aws.proxy.payload2.APIGatewayV2HTTPEventFunction[] for 2.0.
 * New dependency to use <<eventsSerde, Micronaut Serialization with AWS Lambda Events>>.
+* It <<customPojoSerialization, provides a custom serialization implementation for Lambda>>.

--- a/src/main/docs/guide/mnawsfour/mnawsfourBreaks.adoc
+++ b/src/main/docs/guide/mnawsfour/mnawsfourBreaks.adoc
@@ -7,3 +7,4 @@
 `micronaut-function-aws-api-proxy` no longer depends on https://github.com/awslabs/aws-serverless-java-container[AWS Serverless Java container]. Most of the modules classes have been deleted or changed.
 
 If you use `io.micronaut.function.aws.proxy.MicronautLambdaHandler` as your AWS Lambda handler, change it to api:function.aws.proxy.payload1.ApiGatewayProxyRequestEventFunction[] for https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format[Payload format version 1.0] orapi:function.aws.proxy.payload2.APIGatewayV2HTTPEventFunction[] for payload format 2.0.
+

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -45,7 +45,6 @@ sdkv2:
 amazonApiGateway: Amazon API Gateway
 lambda:
   title: AWS Lambda Support
-  eventsLambdaSerde: AWS Lambda Events Serialization
   applicationtypesforawslambda: Micronaut Application Types for AWS Lambda
   awslambdaconsiderations: AWS Lambda Considerations
   awslambdaruntimes: AWS Lambda Runtimes
@@ -53,6 +52,8 @@ lambda:
   lambdatriggers: Lambda Triggers
   lambdacontext: Lambda Context
   requestHandlers: Lambda Handlers
+  customPojoSerialization: Serialization
+  eventsLambdaSerde: AWS Lambda Events Serialization
   afterExecutionEvent: AfterExecutionEvent
   coldstartups: Cold Startups
   customRuntimes: GraalVM and AWS Custom runtimes


### PR DESCRIPTION
This PR modifies `micronaut-function-aws` to provide an implementation of `com.amazonaws.services.lambda.runtime.CustomPojoSerializer` which is loaded via SPI. This `CustomPojoSerialization` avoids your Micronaut function to pay a double hit on performances when using a serialization library inside the Lambda function.