### PR TITLE
Deleted unnecessary AWS STS metadata

### DIFF
--- a/aws-sdk-v2/src/main/resources/META-INF/native-image/io.micronaut.aws/micronaut-aws-sdk-v2/reflect-config.json
+++ b/aws-sdk-v2/src/main/resources/META-INF/native-image/io.micronaut.aws/micronaut-aws-sdk-v2/reflect-config.json
@@ -1,6 +1,0 @@
-[
-  {
-    "name":"software.amazon.awssdk.services.sts.internal.StsWebIdentityCredentialsProviderFactory",
-    "methods":[{"name":"<init>","parameterTypes":[] }]
-  }
-]


### PR DESCRIPTION
Metadata entry for StsWebIdentityCredentialsProviderFactory has been added to awssdk:sts library:

`https://github.com/aws/aws-sdk-java-v2/blob/2.20.80/services/sts/src/main/resources/META-INF/native-image/software.amazon.awssdk/sts/reflect-config.json`

so we don't need it anymore in micronaut-aws