### PR TITLE
Fix MissingBodyAnnotation TCK test

### DIFF
--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV1HttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV1HttpServerTestSuite.java
@@ -12,8 +12,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 })
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Gateway Proxy v1 Event model")
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.MissingBodyAnnotationTest",
-    "io.micronaut.http.server.tck.tests.StreamTest"
+    "io.micronaut.http.server.tck.tests.StreamTest",
 })
 public class FunctionAwsApiGatewayProxyV1HttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/APIGatewayV2HTTPEventFactory.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/APIGatewayV2HTTPEventFactory.java
@@ -21,10 +21,15 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpVersion;
+import io.micronaut.http.MediaType;
+import io.micronaut.json.JsonMapper;
+
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Factory for creating {@link APIGatewayV2HTTPEvent} v2 instances from {@link HttpRequest} instances.
@@ -35,7 +40,24 @@ public final class APIGatewayV2HTTPEventFactory {
     private APIGatewayV2HTTPEventFactory() {
     }
 
-    public static APIGatewayV2HTTPEvent create(HttpRequest<?> request) {
+    public static APIGatewayV2HTTPEvent create(HttpRequest<?> request, JsonMapper jsonMapper) {
+        Function<Object, String> maybeConvertBody = body -> {
+            // Assume no content type == json
+            boolean mapFromJson = request.getContentType().map(MediaType.APPLICATION_JSON_TYPE::equals).orElse(true);
+            if (body instanceof CharSequence) {
+                return body.toString();
+            } else if (body instanceof byte[]) {
+                return new String(((byte[]) body), request.getCharacterEncoding());
+            } else if (mapFromJson) {
+                try {
+                    return jsonMapper.writeValueAsString(body);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+            }
+            return null;
+        };
         return new APIGatewayV2HTTPEvent() {
 
             @Override
@@ -75,7 +97,7 @@ public final class APIGatewayV2HTTPEventFactory {
 
             @Override
             public String getBody() {
-                return request.getBody(Argument.of(String.class)).orElse(null);
+                return request.getBody().map(maybeConvertBody).orElse(null);
             }
         };
     }

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
@@ -15,6 +15,7 @@ import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.tck.ServerUnderTest;
+import io.micronaut.json.JsonMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,21 +29,23 @@ public class GatewayLambdaServerUnderTest implements ServerUnderTest {
 
     private APIGatewayV2HTTPEventFunction function;
     private Context lambdaContext;
+    private final ApplicationContext ctx;
 
     public GatewayLambdaServerUnderTest(Map<String, Object> properties) {
         properties.put("micronaut.server.context-path", "/");
         properties.put("endpoints.health.service-ready-indicator-enabled", StringUtils.FALSE);
         properties.put("endpoints.refresh.enabled", StringUtils.FALSE);
-        this.function = new APIGatewayV2HTTPEventFunction(ApplicationContext
+        ctx = ApplicationContext
             .builder(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, Environment.TEST)
             .properties(properties)
             .deduceEnvironment(false)
-            .start());
+            .start();
+        this.function = new APIGatewayV2HTTPEventFunction(ctx);
     }
 
     @Override
     public <I, O> HttpResponse<O> exchange(HttpRequest<I> request, Argument<O> bodyType) {
-        APIGatewayV2HTTPEvent requestEvent = APIGatewayV2HTTPEventFactory.create(request);
+        APIGatewayV2HTTPEvent requestEvent = APIGatewayV2HTTPEventFactory.create(request, ctx.getBean(JsonMapper.class));
         APIGatewayV2HTTPResponse responseEvent = function.handleRequest(requestEvent, lambdaContext);
         HttpResponse<O> response = new ApiGatewayProxyResponseEventAdapter<>(responseEvent, function.getApplicationContext().getBean(ConversionService.class));
 

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV2HttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV2HttpServerTestSuite.java
@@ -12,8 +12,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 })
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Gateway Proxy v2 Event model")
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.MissingBodyAnnotationTest",
-    "io.micronaut.http.server.tck.tests.StreamTest"
+    "io.micronaut.http.server.tck.tests.StreamTest",
 })
 public class FunctionAwsApiGatewayProxyV2HttpServerTestSuite {
 }


### PR DESCRIPTION
None of our other TCK tests POST a POJO as a body (we usually craft json as a string).

This picked up that our conversion factory method (to convert it to an AWS event wasn't correctly converting the body back to Json if a POJO was sent.

Closes #1764