### PR TITLE
Fix the AWS tck-function-aws-api-proxy-test tests

### DIFF
--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServer.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -149,12 +149,12 @@ public class AwsApiProxyTestServer implements EmbeddedServer {
     @Override
     public ApplicationContext getApplicationContext() {
         // Return the applicationContext of the handler constructed below, not that of the test-server
-        return ((AwsProxyHandler)server.getHandler()).getApplicationContext();
+        return ((AwsProxyHandler) server.getHandler()).getApplicationContext();
     }
 
     @Override
     public ApplicationConfiguration getApplicationConfiguration() {
-        return applicationContext.getBean(ApplicationConfiguration.class);
+        return getApplicationContext().getBean(ApplicationConfiguration.class);
     }
 
     @Override
@@ -173,8 +173,7 @@ public class AwsApiProxyTestServer implements EmbeddedServer {
 
         public AwsProxyHandler(ApplicationContext proxyTestApplicationContext) {
             ApplicationContextBuilder builder = ApplicationContext.builder();
-            for (PropertySource propertySource : proxyTestApplicationContext.getEnvironment()
-                    .getPropertySources()) {
+            for (PropertySource propertySource : proxyTestApplicationContext.getEnvironment().getPropertySources()) {
                 builder = builder.propertySources(propertySource);
             }
             lambdaHandler = new APIGatewayV2HTTPEventFunction(builder.build());
@@ -201,8 +200,7 @@ public class AwsApiProxyTestServer implements EmbeddedServer {
             }
         }
 
-        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response)
-                throws IOException {
+        public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
             APIGatewayV2HTTPEvent awsProxyRequest = requestAdapter.createAwsProxyRequest(request);
             APIGatewayV2HTTPResponse apiGatewayV2HTTPResponse = lambdaHandler.handleRequest(awsProxyRequest, contextProvider.getContext());
             responseAdapter.handle(conversionService, request, apiGatewayV2HTTPResponse, response);

--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServer.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServer.java
@@ -148,7 +148,8 @@ public class AwsApiProxyTestServer implements EmbeddedServer {
 
     @Override
     public ApplicationContext getApplicationContext() {
-        return applicationContext;
+        // Return the applicationContext of the handler constructed below, not that of the test-server
+        return ((AwsProxyHandler)server.getHandler()).getApplicationContext();
     }
 
     @Override
@@ -182,6 +183,10 @@ public class AwsApiProxyTestServer implements EmbeddedServer {
             this.requestAdapter = ctx.getBean(ServletToAwsProxyRequestAdapter.class);
             this.responseAdapter = ctx.getBean(ServletToAwsProxyResponseAdapter.class);
             this.conversionService = ctx.getBean(ConversionService.class);
+        }
+
+        ApplicationContext getApplicationContext() {
+            return lambdaHandler.getApplicationContext();
         }
 
         @Override

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/build.gradle.kts
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/build.gradle.kts
@@ -6,4 +6,5 @@ dependencies {
     testImplementation(projects.micronautFunctionAwsApiProxyTest)
     testImplementation(projects.micronautFunctionAwsApiProxy)
     testImplementation(mnValidation.micronaut.validation)
+    testRuntimeOnly(mn.snakeyaml)
 }

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -12,7 +12,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.FilterErrorTest",
     "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest", // We seem to have 2 instances of RefreshCounter!?
     "io.micronaut.http.server.tck.tests.cors.SimpleRequestWithCorsNotEnabledTest",
-    "io.micronaut.http.server.tck.tests.endpoints.health.HealthTest",
     "io.micronaut.http.server.tck.tests.filter.RequestFilterTest",
     "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
 })

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -10,8 +10,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Proxy Test")
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.FilterErrorTest",
-    "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest", // We seem to have 2 instances of RefreshCounter!?
-    "io.micronaut.http.server.tck.tests.cors.SimpleRequestWithCorsNotEnabledTest",
     "io.micronaut.http.server.tck.tests.filter.RequestFilterTest",
     "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
 })

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -15,7 +15,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.tests.endpoints.health.HealthTest",
     "io.micronaut.http.server.tck.tests.filter.RequestFilterTest",
     "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
-    "io.micronaut.http.server.tck.tests.StreamTest" // Broken in servlet
 })
 public class MicronautLambdaHandlerHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -1,6 +1,5 @@
 package io.micronaut.http.server.tck.lambda.tests;
 
-import org.junit.platform.suite.api.ExcludeClassNamePatterns;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
@@ -8,10 +7,5 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Proxy Test")
-@ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.FilterErrorTest",
-    "io.micronaut.http.server.tck.tests.filter.RequestFilterTest",
-    "io.micronaut.http.server.tck.tests.filter.ResponseFilterTest",
-})
 public class MicronautLambdaHandlerHttpServerTestSuite {
 }

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/resources/application.yml
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+endpoints:
+  health:
+    service-ready-indicator-enabled: false


### PR DESCRIPTION
We had two issues here.

1. We needed to switch off the AWS health status (as with the other TCK tests)
    To do this, we use a property in a yaml file
2. When we ran the tests we have 2 application contexts.
    One of them is in the Lambda handler -- this is the one we want
    The other is in the test-server -- this is the one we don't want
    Tests were failing as we were using beans from one in the test, and then beans from the other in the assertion.
    Fixed by returning the handler application context from the test-server