### PR TITLE
fix: request.getUri should respond include path and query values

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -36,6 +36,7 @@ import io.micronaut.http.MutableHttpParameters;
 import io.micronaut.http.MutableHttpRequest;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
+import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.servlet.http.MutableServletHttpRequest;
 import io.micronaut.servlet.http.BodyBuilder;
 import io.micronaut.servlet.http.ServletExchange;
@@ -107,6 +108,17 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
     }
 
     public abstract byte[] getBodyBytes() throws IOException;
+
+    protected static URI buildUri(
+        String path,
+        Map<String,String> queryParameters,
+        Map<String,List<String>> multiQueryParameters
+    ) {
+        UriBuilder uriBuilder = UriBuilder.of(path);
+        queryParameters.forEach((key, value) -> splitCommaSeparatedValue(value).forEach(token -> uriBuilder.queryParam(key, token)));
+        multiQueryParameters.forEach((key, values) -> values.forEach(value -> uriBuilder.queryParam(key, value)));
+        return uriBuilder.build();
+    }
 
     protected static HttpMethod parseMethod(Supplier<String> httpMethodConsumer) {
         try {

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -120,12 +120,16 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
      */
     protected static URI buildUri(
         String path,
-        Map<String, String> queryParameters,
-        Map<String, List<String>> multiQueryParameters
+        @Nullable Map<String, String> queryParameters,
+        @Nullable Map<String, List<String>> multiQueryParameters
     ) {
         UriBuilder uriBuilder = UriBuilder.of(path);
-        queryParameters.forEach((key, value) -> splitCommaSeparatedValue(value).forEach(token -> uriBuilder.queryParam(key, token)));
-        multiQueryParameters.forEach((key, values) -> values.forEach(value -> uriBuilder.queryParam(key, value)));
+        if (queryParameters != null) {
+            queryParameters.forEach((key, value) -> splitCommaSeparatedValue(value).forEach(token -> uriBuilder.queryParam(key, token)));
+        }
+        if (multiQueryParameters != null) {
+            multiQueryParameters.forEach((key, values) -> values.forEach(value -> uriBuilder.queryParam(key, value)));
+        }
         return uriBuilder.build();
     }
 

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -109,6 +109,15 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
 
     public abstract byte[] getBodyBytes() throws IOException;
 
+    /**
+     * Given a path and the query params from the event, build a URI.
+     *
+     * @param path the request path
+     * @param queryParameters the query parameters from the event
+     * @param multiQueryParameters the multi-value query parameters from the event
+     * @return the URI
+     * @since 4.0.3
+     */
     protected static URI buildUri(
         String path,
         Map<String,String> queryParameters,

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -120,8 +120,8 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
      */
     protected static URI buildUri(
         String path,
-        Map<String,String> queryParameters,
-        Map<String,List<String>> multiQueryParameters
+        Map<String, String> queryParameters,
+        Map<String, List<String>> multiQueryParameters
     ) {
         UriBuilder uriBuilder = UriBuilder.of(path);
         queryParameters.forEach((key, value) -> splitCommaSeparatedValue(value).forEach(token -> uriBuilder.queryParam(key, token)));

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerServletRequest.java
@@ -54,7 +54,11 @@ public class ApplicationLoadBalancerServletRequest<B> extends ApiGatewayServletR
         super(
             conversionService,
             requestEvent,
-            ApiGatewayServletRequest.buildUri(requestEvent.getPath(), requestEvent.getQueryStringParameters(), requestEvent.getMultiValueQueryStringParameters()),
+            ApiGatewayServletRequest.buildUri(
+                requestEvent.getPath(),
+                requestEvent.getQueryStringParameters(),
+                requestEvent.getMultiValueQueryStringParameters()
+            ),
             parseMethod(requestEvent::getHttpMethod),
             LOG,
             bodyBuilder

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerServletRequest.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
 
 /**
  * Implementation of {@link ServletHttpRequest} for Application Load Balancer events.

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerServletRequest.java
@@ -54,7 +54,7 @@ public class ApplicationLoadBalancerServletRequest<B> extends ApiGatewayServletR
         super(
             conversionService,
             requestEvent,
-            URI.create(requestEvent.getPath()),
+            ApiGatewayServletRequest.buildUri(requestEvent.getPath(), requestEvent.getQueryStringParameters(), requestEvent.getMultiValueQueryStringParameters()),
             parseMethod(requestEvent::getHttpMethod),
             LOG,
             bodyBuilder

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
@@ -56,7 +56,11 @@ public final class ApiGatewayProxyServletRequest<B> extends ApiGatewayServletReq
         super(
             conversionService,
             requestEvent,
-            URI.create(requestEvent.getPath()),
+            ApiGatewayServletRequest.buildUri(
+                requestEvent.getPath(),
+                requestEvent.getQueryStringParameters(),
+                requestEvent.getMultiValueQueryStringParameters()
+            ),
             parseMethod(requestEvent::getHttpMethod),
             LOG,
             bodyBuilder

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
@@ -30,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Base64;
 
 /**

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
@@ -55,7 +55,11 @@ public final class APIGatewayV2HTTPEventServletRequest<B> extends ApiGatewayServ
         super(
             conversionService,
             requestEvent,
-            URI.create(requestEvent.getRequestContext().getHttp().getPath()),
+            ApiGatewayServletRequest.buildUri(
+                requestEvent.getRequestContext().getHttp().getPath(),
+                requestEvent.getQueryStringParameters(),
+                Collections.emptyMap()
+            ),
             parseMethod(() -> requestEvent.getRequestContext().getHttp().getMethod()),
             LOG,
             bodyBuilder

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Collections;
 
 /**

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-alb/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-alb/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.lambda.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import io.micronaut.http.uri.UriBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+//TODO Delete when https://github.com/micronaut-projects/micronaut-core/pull/9791
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class RequestUriContainsQueryValueTest {
+
+    public static final String SPEC_NAME = "RequestUriContainsQueryValueTest";
+
+    @Test
+    void testRequestUriContainsQueryValue() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET(UriBuilder.of("/requesturi").queryParam("foo", "bar").build()),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .body("/requesturi?foo=bar")
+                    .build()));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller("/requesturi")
+    static class TestController {
+        @Get
+        String index(HttpRequest<?> request) {
+            return request.getUri().toASCIIString();
+        }
+    }
+}

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.lambda.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import io.micronaut.http.uri.UriBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+//TODO Delete when https://github.com/micronaut-projects/micronaut-core/pull/9791
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class RequestUriContainsQueryValueTest {
+
+    public static final String SPEC_NAME = "RequestUriContainsQueryValueTest";
+
+    @Test
+    void testRequestUriContainsQueryValue() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET(UriBuilder.of("/requesturi").queryParam("foo", "bar").build()),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .body("/requesturi?foo=bar")
+                    .build()));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller("/requesturi")
+    static class TestController {
+        @Get
+        String index(HttpRequest<?> request) {
+            return request.getUri().toASCIIString();
+        }
+    }
+}

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.lambda.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import io.micronaut.http.uri.UriBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+//TODO Delete when https://github.com/micronaut-projects/micronaut-core/pull/9791
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class RequestUriContainsQueryValueTest {
+
+    public static final String SPEC_NAME = "RequestUriContainsQueryValueTest";
+
+    @Test
+    void testRequestUriContainsQueryValue() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET(UriBuilder.of("/requesturi").queryParam("foo", "bar").build()),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .body("/requesturi?foo=bar")
+                    .build()));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller("/requesturi")
+    static class TestController {
+        @Get
+        String index(HttpRequest<?> request) {
+            return request.getUri().toASCIIString();
+        }
+    }
+}

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -6,7 +6,10 @@ import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
-@SelectPackages("io.micronaut.http.server.tck.tests")
+@SelectPackages({
+    "io.micronaut.http.server.tck.tests",
+    "io.micronaut.http.server.tck.lambda.tests"
+})
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.LocalErrorReadingBodyTest", // Binding body different type (e.g. a String in error handler)
     "io.micronaut.http.server.tck.tests.FilterProxyTest" // Immmutable request

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/RequestUriContainsQueryValueTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.lambda.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import io.micronaut.http.uri.UriBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+//TODO Delete when https://github.com/micronaut-projects/micronaut-core/pull/9791
+@SuppressWarnings({
+    "java:S5960", // We're allowed assertions, as these are used in tests only
+    "checkstyle:MissingJavadocType",
+    "checkstyle:DesignForExtension"
+})
+public class RequestUriContainsQueryValueTest {
+
+    public static final String SPEC_NAME = "RequestUriContainsQueryValueTest";
+
+    @Test
+    void testRequestUriContainsQueryValue() throws IOException {
+        asserts(SPEC_NAME,
+            HttpRequest.GET(UriBuilder.of("/requesturi").queryParam("foo", "bar").build()),
+            (server, request) -> AssertionUtils.assertDoesNotThrow(server, request,
+                HttpResponseAssertion.builder()
+                    .status(HttpStatus.OK)
+                    .body("/requesturi?foo=bar")
+                    .build()));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller("/requesturi")
+    static class TestController {
+        @Get
+        String index(HttpRequest<?> request) {
+            return request.getUri().toASCIIString();
+        }
+    }
+}


### PR DESCRIPTION
see: https://github.com/micronaut-projects/micronaut-aws/issues/1848

I added the same test to the core TCK I have added a test in the TCK https://github.com/micronaut-projects/micronaut-core/pull/9791