### PR TITLE
fix: multi value header handling

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -357,6 +357,6 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
      */
     @NonNull
     protected MutableHttpHeaders getHeaders(@NonNull Supplier<Map<String, String>> singleHeaders, @NonNull Supplier<Map<String, List<String>>> multiValueHeaders) {
-        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(multiValueHeaders.get(), singleHeaders.get()), conversionService);
+        return new CaseInsensitiveMutableHttpHeaders(HeaderMapCollapseUtils.collapse(multiValueHeaders.get(), singleHeaders.get()), conversionService);
     }
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/HeaderMapCollapseUtils.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/HeaderMapCollapseUtils.java
@@ -27,8 +27,9 @@ import java.util.Map;
  * Utility methods for collapsing HTTP Headers.
  */
 @Internal
-public class HeaderMapCollapseUtils {
+public final class HeaderMapCollapseUtils {
     private static final List<String> HEADERS_ALLOWING_COMMAS = Arrays.asList(HttpHeaders.DATE, HttpHeaders.USER_AGENT);
+
     private HeaderMapCollapseUtils() {
 
     }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/HeaderMapCollapseUtils.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/HeaderMapCollapseUtils.java
@@ -23,9 +23,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Utility methods for collapsing HTTP Headers.
+ */
 @Internal
 public class HeaderMapCollapseUtils {
     private static final List<String> HEADERS_ALLOWING_COMMAS = Arrays.asList(HttpHeaders.DATE, HttpHeaders.USER_AGENT);
+    private HeaderMapCollapseUtils() {
+
+    }
 
     /**
      * Collapse the aws single and multi headers into a single value map.

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/HeaderMapCollapseUtils.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/HeaderMapCollapseUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.HttpHeaders;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+@Internal
+public class HeaderMapCollapseUtils {
+    private static final List<String> HEADERS_ALLOWING_COMMAS = Arrays.asList(HttpHeaders.DATE, HttpHeaders.USER_AGENT);
+
+    /**
+     * Collapse the aws single and multi headers into a single value map.
+     *
+     * @param multi  The multi value map
+     * @param single The single value map
+     * @return The map
+     */
+    public static Map<String, List<String>> collapse(@Nullable Map<String, List<String>> multi,
+                                                     @Nullable Map<String, String> single) {
+        return MapCollapseUtils.collapse(multi, single, MapCollapseUtils.COMMA, HEADERS_ALLOWING_COMMAS);
+    }
+}

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapCollapseUtils.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapCollapseUtils.java
@@ -88,23 +88,28 @@ public final class MapCollapseUtils {
         if (CollectionUtils.isNotEmpty(single)) {
             for (var entry: single.entrySet()) {
                 String headerName = entry.getKey();
-                List<String> strings = values.computeIfAbsent(headerName, s -> new ArrayList<>());
-                String value = entry.getValue();
-                if (HEADERS_ALLOWING_COMMAS.contains(headerName)) {
-                    if (!strings.contains(value)) {
-                        strings.add(value);
-                    }
-                } else {
-                    for (String v : splitCommaSeparatedValue(value)) {
-                        v = v.trim();
-                        if (!strings.contains(v)) {
-                            strings.add(v);
-                        }
-                    }
-                }
+                List<String> headerValues = values.computeIfAbsent(headerName, s -> new ArrayList<>());
+                populateHeaderValues(headerName, entry.getValue(), headerValues);
             }
         }
         return values;
+    }
+
+    private static void populateHeaderValues(@NonNull String headerName,
+                                      @NonNull String headerValue,
+                                      List<String> headerValues) {
+        if (HEADERS_ALLOWING_COMMAS.contains(headerName)) {
+            if (!headerValues.contains(headerValue)) {
+                headerValues.add(headerValue);
+            }
+        } else {
+            for (String v : splitCommaSeparatedValue(headerValue)) {
+                v = v.trim();
+                if (!headerValues.contains(v)) {
+                    headerValues.add(v);
+                }
+            }
+        }
     }
 
     /**

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerResponseEventAdapter.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerResponseEventAdapter.java
@@ -22,7 +22,7 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
 import io.micronaut.core.util.ArgumentUtils;
-import io.micronaut.function.aws.proxy.MapCollapseUtils;
+import io.micronaut.function.aws.proxy.HeaderMapCollapseUtils;
 import io.micronaut.http.CaseInsensitiveMutableHttpHeaders;
 import io.micronaut.http.HttpStatus;
 import io.micronaut.http.MutableHttpHeaders;
@@ -62,7 +62,7 @@ public class ApplicationLoadBalancerResponseEventAdapter<T> implements MutableHt
 
     @Override
     public MutableHttpHeaders getHeaders() {
-        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(event.getMultiValueHeaders(), event.getHeaders()), conversionService);
+        return new CaseInsensitiveMutableHttpHeaders(HeaderMapCollapseUtils.collapse(event.getMultiValueHeaders(), event.getHeaders()), conversionService);
     }
 
     @Override

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyResponseEventAdapter.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyResponseEventAdapter.java
@@ -17,7 +17,7 @@ package io.micronaut.function.aws.proxy.payload1;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.function.aws.proxy.MapCollapseUtils;
+import io.micronaut.function.aws.proxy.HeaderMapCollapseUtils;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -61,7 +61,7 @@ public class ApiGatewayProxyResponseEventAdapter<T> implements MutableHttpRespon
 
     @Override
     public MutableHttpHeaders getHeaders() {
-        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(event.getMultiValueHeaders(), event.getHeaders()), conversionService);
+        return new CaseInsensitiveMutableHttpHeaders(HeaderMapCollapseUtils.collapse(event.getMultiValueHeaders(), event.getHeaders()), conversionService);
     }
 
     @Override

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/ApiGatewayProxyResponseEventAdapter.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/ApiGatewayProxyResponseEventAdapter.java
@@ -17,7 +17,7 @@ package io.micronaut.function.aws.proxy.payload2;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.function.aws.proxy.MapCollapseUtils;
+import io.micronaut.function.aws.proxy.HeaderMapCollapseUtils;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.value.MutableConvertibleValues;
 import io.micronaut.core.convert.value.MutableConvertibleValuesMap;
@@ -61,7 +61,7 @@ public class ApiGatewayProxyResponseEventAdapter<T> implements MutableHttpRespon
 
     @Override
     public MutableHttpHeaders getHeaders() {
-        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(event.getMultiValueHeaders(), event.getHeaders()), conversionService);
+        return new CaseInsensitiveMutableHttpHeaders(HeaderMapCollapseUtils.collapse(event.getMultiValueHeaders(), event.getHeaders()), conversionService);
     }
 
     @Override

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapCollapseUtilsSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapCollapseUtilsSpec.groovy
@@ -33,7 +33,7 @@ class MapCollapseUtilsSpec extends Specification {
         event.setHeaders(headers)
 
         when:
-        MutableHttpHeaders httpHeaders = new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(Collections.emptyMap(), event.getHeaders()), conversionService);
+        MutableHttpHeaders httpHeaders = new CaseInsensitiveMutableHttpHeaders(HeaderMapCollapseUtils.collapse(Collections.emptyMap(), event.getHeaders()), conversionService);
 
         then:
         noExceptionThrown()
@@ -64,7 +64,7 @@ class MapCollapseUtilsSpec extends Specification {
         request.setMultiValueHeaders(multiValueHeaders)
 
         when:
-        MutableHttpHeaders httpHeaders = new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(request.getMultiValueHeaders(), request.getHeaders()), conversionService);
+        MutableHttpHeaders httpHeaders = new CaseInsensitiveMutableHttpHeaders(HeaderMapCollapseUtils.collapse(request.getMultiValueHeaders(), request.getHeaders()), conversionService);
 
         then:
         noExceptionThrown()

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapCollapseUtilsSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapCollapseUtilsSpec.groovy
@@ -1,0 +1,77 @@
+package io.micronaut.function.aws.proxy
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent
+import io.micronaut.core.convert.ConversionService
+import io.micronaut.http.CaseInsensitiveMutableHttpHeaders
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.MutableHttpHeaders
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class MapCollapseUtilsSpec extends Specification {
+
+    @Inject
+    ConversionService conversionService
+
+    /**
+     *
+     * GET /prod/ HTTP/1.1
+     * Key: value1,value2,value3
+     * Foo: Bar
+     */
+    void "payload v2 example"() {
+        given:
+        APIGatewayV2HTTPEvent event = new APIGatewayV2HTTPEvent()
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaders.DATE, "Wed, 21 Oct 2015 07:28:00 GMT")
+        headers.put("foo", "Bar")
+        headers.put("key", "value1,value2,value3")
+        headers.put(HttpHeaders.USER_AGENT, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)")
+        event.setHeaders(headers)
+
+        when:
+        MutableHttpHeaders httpHeaders = new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(Collections.emptyMap(), event.getHeaders()), conversionService);
+
+        then:
+        noExceptionThrown()
+
+        and:
+        "Bar" == httpHeaders.get("Foo")
+        ["value1", "value2", "value3"] == httpHeaders.getAll("Key")
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko)" == httpHeaders.get(HttpHeaders.USER_AGENT)
+        "Wed, 21 Oct 2015 07:28:00 GMT" == httpHeaders.get(HttpHeaders.DATE)
+    }
+
+    /**
+     *
+     * GET /prod/ HTTP/1.1
+     * Key: value1,value2,value3
+     * Foo: Bar
+     */
+    void "payload v1 example"() {
+        given:
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent()
+        Map<String, String> headers = new HashMap<>()
+        headers.put("Foo", "Bar")
+        headers.put("Key", "value1,value2,value3")
+        request.setHeaders(headers)
+        Map<String, List<String>> multiValueHeaders = new HashMap<>()
+        multiValueHeaders.put("Key", Arrays.asList("value1", "value2", "value3"))
+        multiValueHeaders.put("Foo", Collections.singletonList("Bar"))
+        request.setMultiValueHeaders(multiValueHeaders)
+
+        when:
+        MutableHttpHeaders httpHeaders = new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(request.getMultiValueHeaders(), request.getHeaders()), conversionService);
+
+        then:
+        noExceptionThrown()
+
+        and:
+        "Bar" == httpHeaders.get("Foo")
+        ["value1", "value2", "value3"] == httpHeaders.getAll("Key")
+
+    }
+}

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/APIGatewayV2HTTPEventFactory.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/APIGatewayV2HTTPEventFactory.java
@@ -33,6 +33,7 @@ import java.util.Optional;
  */
 @Internal
 public final class APIGatewayV2HTTPEventFactory {
+    private final static String COMMA = ",";
 
     private APIGatewayV2HTTPEventFactory() {
     }
@@ -44,7 +45,7 @@ public final class APIGatewayV2HTTPEventFactory {
             public Map<String, String> getHeaders() {
                 Map<String, String> result = new HashMap<>();
                 for (String headerName : request.getHeaders().names()) {
-                    result.put(headerName, request.getHeaders().get(headerName));
+                    result.put(headerName, String.join(COMMA, request.getHeaders().getAll(headerName)));
                 }
                 return result;
             }

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV2HttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV2HttpServerTestSuite.java
@@ -11,7 +11,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.lambda.tests"
 })
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.HeadersTest", // https://github.com/micronaut-projects/micronaut-aws/issues/1861
     "io.micronaut.http.server.tck.tests.FilterProxyTest" // Immmutable request
 })
 @SuiteDisplayName("HTTP Server TCK for Function AWS API Gateway Proxy v2 Event model")

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -11,7 +11,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.lambda.tests"
 })
 @ExcludeClassNamePatterns({
-    "io.micronaut.http.server.tck.tests.HeadersTest", // https://github.com/micronaut-projects/micronaut-aws/issues/1861
     "io.micronaut.http.server.tck.tests.LocalErrorReadingBodyTest", // Binding body different type (e.g. a String in error handler)
     "io.micronaut.http.server.tck.tests.FilterProxyTest" // Immmutable request
 


### PR DESCRIPTION
Close #1861

[Multi-header values should use a comma](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2): 

> Multiple message-header fields with the same field-name MAY be
   present in a message if and only if the entire field-value for that
   header field is defined as a comma-separated list [i.e., #(values)].
   It MUST be possible to combine the multiple header fields into one
   "field-name: field-value" pair, without changing the semantics of the
   message, by appending each subsequent field-value to the first, each
   separated by a comma.

But there are headers which have a , without using it to designate a multi-value. [E.g. Date](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date).  Thus, a mess 🤷🏼‍♂️
 