### PR TITLE
docs: fix dependency for lambda handlers

### DIFF
--- a/src/main/docs/guide/lambda/requestHandlers.adoc
+++ b/src/main/docs/guide/lambda/requestHandlers.adoc
@@ -40,13 +40,13 @@ For functions of type `Application`, use the handler:
 
 To resolve that class you need to add the `micronaut-function-aws-api-proxy` dependency to your build.
 
-dependency:micronaut-function-aws-api-proxy[]
+dependency:micronaut-function-aws-api-proxy[groupId="io.micronaut.aws"]
 
 For Serverless Functions the decision to use one `MicronautRequestHandler` or `MicronautRequestStreamHandler` depends on how you want to handle the input and output types.
 
 To resolve those classes you need to add the `micronaut-function-aws` dependency to your build.
 
-dependency:micronaut-function-aws[]
+dependency:micronaut-function-aws[groupId="io.micronaut.aws"]
 
 With api:function.aws.MicronautRequestHandler[], it is expected that you supply generic types with the input and the output types. If you wish to work with raw streams then subclass api:function.aws.MicronautRequestStreamHandler[] instead.
 


### PR DESCRIPTION
The packages `micronaut-function-aws` and `micronaut-function-aws-api-proxy` are part of the group `io.micronaut.aws` and not `io.micronaut`.