### PR TITLE
Failing test for issue 1870

### DIFF
--- a/function-aws-test/build.gradle.kts
+++ b/function-aws-test/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 
     testAnnotationProcessor(mn.micronaut.inject.java)
 
+    testImplementation("org.mockito:mockito-core:5.3.1")
     testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(mn.snakeyaml)
     testRuntimeOnly(mnSerde.micronaut.serde.jackson)

--- a/function-aws-test/src/test/java/io/micronaut/function/aws/test/EagerSingleton.java
+++ b/function-aws-test/src/test/java/io/micronaut/function/aws/test/EagerSingleton.java
@@ -4,4 +4,8 @@ import jakarta.inject.Singleton;
 
 @Singleton
 public class EagerSingleton {
+
+    public String hello(String name) {
+        return "hello %s".formatted(name);
+    }
 }

--- a/function-aws-test/src/test/java/io/micronaut/function/aws/test/MicronautLambdaExtensionMockBeanTest.java
+++ b/function-aws-test/src/test/java/io/micronaut/function/aws/test/MicronautLambdaExtensionMockBeanTest.java
@@ -1,0 +1,59 @@
+package io.micronaut.function.aws.test;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.function.aws.MicronautRequestHandler;
+import io.micronaut.function.aws.test.annotation.MicronautLambdaTest;
+import io.micronaut.test.annotation.MockBean;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@Disabled("This test fails when annotated with @MicronautLambdaTest but passes when annotated with @MicronautTest")
+@MicronautLambdaTest
+//@MicronautTest
+class MicronautLambdaExtensionMockBeanTest {
+
+    @Inject
+    ApplicationContext context;
+
+    @Inject
+    EagerSingleton eagerSingleton;
+
+    @Test
+    void testSingletonIsSingle() {
+        when(eagerSingleton.hello("world")).thenReturn("hello world");
+        TestHandler handler = new TestHandler(context);
+        assertEquals("hello world", handler.execute("world"));
+        verify(eagerSingleton).hello("world");
+    }
+
+    @MockBean(EagerSingleton.class)
+    EagerSingleton eagerSingleton() {
+        return mock(EagerSingleton.class);
+    }
+
+    static class TestHandler extends MicronautRequestHandler<String, String> {
+
+        @Inject
+        EagerSingleton singleton;
+
+        //used in AWS
+        public TestHandler() {
+        }
+
+        //used in tests
+        public TestHandler(ApplicationContext applicationContext) {
+            super(applicationContext);
+        }
+
+        @Override
+        public String execute(String input) {
+            return singleton.hello(input);
+        }
+    }
+}

--- a/function-aws-test/src/test/resources/logback.xml
+++ b/function-aws-test/src/test/resources/logback.xml
@@ -12,4 +12,5 @@
         <appender-ref ref="STDOUT" />
     </root>
     <logger name="io.micronaut.function.aws" level="TRACE"/>
+    <logger name="io.micronaut.context" level="TRACE"/>
 </configuration>


### PR DESCRIPTION
When annotated with `@MicronautLambdaTest`, this test fails.

It is because the `EagerSingleton` inside the Hander and the Test are 2 different mocks.

When this test is run with `@MicronautTest` then it passes...

It  must be something to do with Environments, as using

```
@MicronautTest(environments = {Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, Environment.TEST})
```

Also fails with the same issue...