### PR TITLE
fix: allow single headers without specifying multi-value headers to b…

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapCollapseUtils.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapCollapseUtils.java
@@ -81,6 +81,9 @@ public final class MapCollapseUtils {
         }
         if (CollectionUtils.isNotEmpty(single)) {
             for (var entry: single.entrySet()) {
+                if (values.containsKey(entry.getKey())) {
+                    continue;
+                }
                 List<String> strings = values.computeIfAbsent(entry.getKey(), s -> new ArrayList<>());
                 if (!strings.contains(entry.getValue())) {
                     strings.add(entry.getValue());

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
@@ -21,6 +21,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.proxy.ApiGatewayServletRequest;
+import io.micronaut.function.aws.proxy.MapCollapseUtils;
 import io.micronaut.http.CaseInsensitiveMutableHttpHeaders;
 import io.micronaut.http.MutableHttpHeaders;
 import io.micronaut.http.MutableHttpParameters;
@@ -31,10 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Implementation of {@link ServletHttpRequest} for AWS API Gateway Proxy.
@@ -84,7 +82,8 @@ public final class ApiGatewayProxyServletRequest<B> extends ApiGatewayServletReq
     @Override
     public MutableHttpHeaders getHeaders() {
         Map<String, List<String>> multiValueHeaders = requestEvent.getMultiValueHeaders();
-        return new CaseInsensitiveMutableHttpHeaders(multiValueHeaders != null ? multiValueHeaders : Collections.emptyMap(), conversionService);
+        Map<String, String> singleValueHeaders = requestEvent.getHeaders();
+        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(multiValueHeaders, singleValueHeaders), conversionService);
     }
 
     @Override

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
@@ -32,7 +32,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link ServletHttpRequest} for AWS API Gateway Proxy.

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValueSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValueSpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.function.aws.proxy
 
 import io.micronaut.core.convert.ConversionService
+import spock.lang.Narrative
+import spock.lang.See
 import spock.lang.Specification
 
 class MapListOfStringAndMapStringConvertibleMultiValueSpec extends Specification {
@@ -37,16 +39,17 @@ class MapListOfStringAndMapStringConvertibleMultiValueSpec extends Specification
         map.get('foo') == 'bar'
     }
 
-    void "coalescence works as expected"() {
+    @See("https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format")
+    void "If the same key-value pair is specified in both, only the values from multiValueHeaders will appear in the merged list"() {
         given:
-        def multi = ['foo': ['bar', 'baz']]
-        def single = ['foo': 'qux']
-        def map = new MapListOfStringAndMapStringConvertibleMultiValue(ConversionService.SHARED, multi, single)
+        Map<String, List<String>> multi = ['foo': ['bar', 'baz']]
+        Map<String, String> single = ['foo': 'qux']
+        MapListOfStringAndMapStringConvertibleMultiValue map = new MapListOfStringAndMapStringConvertibleMultiValue(ConversionService.SHARED, multi, single)
 
         expect:
         map.size() == 1
-        map.getAll('foo') == ['bar', 'baz', 'qux']
-        map.getAll('FOO') == ['bar', 'baz', 'qux']
+        map.getAll('foo') == ['bar', 'baz']
+        map.getAll('FOO') == ['bar', 'baz']
         map.get('foo') == 'bar'
     }
 }

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValueSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValueSpec.groovy
@@ -1,7 +1,6 @@
 package io.micronaut.function.aws.proxy
 
 import io.micronaut.core.convert.ConversionService
-import spock.lang.Narrative
 import spock.lang.See
 import spock.lang.Specification
 

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerFunctionSingleHeaderSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerFunctionSingleHeaderSpec.groovy
@@ -4,8 +4,6 @@ import com.amazonaws.services.lambda.runtime.ClientContext
 import com.amazonaws.services.lambda.runtime.CognitoIdentity
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.LambdaLogger
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerRequestEvent
 import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerResponseEvent
 import io.micronaut.context.ApplicationContext

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerFunctionSingleHeaderSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/alb/ApplicationLoadBalancerFunctionSingleHeaderSpec.groovy
@@ -1,0 +1,61 @@
+package io.micronaut.function.aws.proxy.alb
+
+import com.amazonaws.services.lambda.runtime.ClientContext
+import com.amazonaws.services.lambda.runtime.CognitoIdentity
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerRequestEvent
+import com.amazonaws.services.lambda.runtime.events.ApplicationLoadBalancerResponseEvent
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import spock.lang.Specification
+
+class ApplicationLoadBalancerFunctionSingleHeaderSpec extends Specification {
+
+    void "should retrieve and validate the header"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.builder().properties('micronaut.security.enabled': false, 'spec.name': 'ApplicationLoadBalancerFunctionSingleHeaderSpec').build()
+        ApplicationLoadBalancerFunction handler = new ApplicationLoadBalancerFunction(ctx)
+
+        ApplicationLoadBalancerRequestEvent request = new ApplicationLoadBalancerRequestEvent();
+        request.setPath("/single-value-header")
+        request.setHttpMethod("GET")
+        request.setHeaders(Map.of(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN, "sample-header", "HERE IT IS"))
+
+        when:
+        ApplicationLoadBalancerResponseEvent response = handler.handleRequest(request, createContext())
+
+        then:
+        200 == response.statusCode
+        'HERE IT IS' == response.body
+    }
+
+    private Context createContext() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> Mock(CognitoIdentity)
+            getClientContext() >> Mock(ClientContext)
+            getClientContext() >> Mock(ClientContext)
+            getLogger() >> Mock(LambdaLogger)
+        }
+    }
+
+    @Requires(property = "spec.name", value = 'ApplicationLoadBalancerFunctionSingleHeaderSpec')
+    @Controller
+    static class SampleController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/single-value-header")
+        String singleValueHeader(HttpRequest<?> request) {
+            return request.getHeaders().get("sample-header", String.class).orElse("HEADER NOT DEFINED");
+        }
+    }
+}

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyRequestEventFunctionSingleHeaderSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyRequestEventFunctionSingleHeaderSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.function.aws.proxy.payload1
+
+import com.amazonaws.services.lambda.runtime.ClientContext
+import com.amazonaws.services.lambda.runtime.CognitoIdentity
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import spock.lang.Specification
+
+class ApiGatewayProxyRequestEventFunctionSingleHeaderSpec extends Specification {
+
+    void "should retrieve and validate the header"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.builder().properties('micronaut.security.enabled': false, 'spec.name': 'ApiGatewayProxyRequestEventFunctionSingleHeaderSpec').build()
+        ApiGatewayProxyRequestEventFunction handler = new ApiGatewayProxyRequestEventFunction(ctx)
+
+        when:
+        APIGatewayProxyResponseEvent response = handler.handleRequest(new APIGatewayProxyRequestEvent()
+                .withHttpMethod("GET")
+                .withPath("/single-value-header")
+                .withHeaders(Map.of(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN, "sample-header", "HERE IT IS")), createContext())
+
+        then:
+        200 == response.statusCode
+        'HERE IT IS' == response.body
+    }
+
+    private Context createContext() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> Mock(CognitoIdentity)
+            getClientContext() >> Mock(ClientContext)
+            getClientContext() >> Mock(ClientContext)
+            getLogger() >> Mock(LambdaLogger)
+        }
+    }
+
+    @Requires(property = "spec.name", value = 'ApiGatewayProxyRequestEventFunctionSingleHeaderSpec')
+    @Controller
+    static class SampleController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/single-value-header")
+        String singleValueHeader(HttpRequest<?> request) {
+            return request.getHeaders().get("sample-header", String.class).orElse("HEADER NOT DEFINED");
+        }
+    }
+}

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionSingleHeaderSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionSingleHeaderSpec.groovy
@@ -1,0 +1,58 @@
+package io.micronaut.function.aws.proxy.payload2
+
+import com.amazonaws.services.lambda.runtime.ClientContext
+import com.amazonaws.services.lambda.runtime.CognitoIdentity
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.LambdaLogger
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.HttpHeaders
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.MediaType
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.Produces
+import spock.lang.Specification
+
+class APIGatewayV2HTTPEventFunctionSingleHeaderSpec extends Specification {
+
+    void "should retrieve and validate the header"() {
+        given:
+        ApplicationContext ctx = ApplicationContext.builder().properties('micronaut.security.enabled': false, 'spec.name': 'APIGatewayV2HTTPEventFunctionSingleHeaderSpec').build()
+        APIGatewayV2HTTPEventFunction handler = new APIGatewayV2HTTPEventFunction(ctx)
+
+        when:
+        APIGatewayV2HTTPEvent event = new APIGatewayV2HTTPEvent()
+        event.setHeaders(Map.of(HttpHeaders.ACCEPT, MediaType.TEXT_PLAIN, "sample-header", "HERE IT IS"))
+        event.setRequestContext(APIGatewayV2HTTPEvent.RequestContext.builder().withHttp(APIGatewayV2HTTPEvent.RequestContext.Http.builder().withPath("/single-value-header").withMethod("GET").build()).build())
+
+        APIGatewayV2HTTPResponse response = handler.handleRequest(event, createContext())
+
+        then:
+        200 == response.statusCode
+        'HERE IT IS' == response.body
+    }
+
+    private Context createContext() {
+        Stub(Context) {
+            getAwsRequestId() >> 'XXX'
+            getIdentity() >> Mock(CognitoIdentity)
+            getClientContext() >> Mock(ClientContext)
+            getClientContext() >> Mock(ClientContext)
+            getLogger() >> Mock(LambdaLogger)
+        }
+    }
+
+    @Requires(property = "spec.name", value = 'APIGatewayV2HTTPEventFunctionSingleHeaderSpec')
+    @Controller
+    static class SampleController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/single-value-header")
+        String singleValueHeader(HttpRequest<?> request) {
+            return request.getHeaders().get("sample-header", String.class).orElse("HEADER NOT DEFINED");
+        }
+    }
+}

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/SingleValueHeaderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/SingleValueHeaderTest.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 
 import static io.micronaut.http.tck.TestScenario.asserts;
 
-public class SingleValueHeaderTest {
+class SingleValueHeaderTest {
     private static final String SPEC_NAME = "SingleValueHeaderTest";
 
     @Test

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/SingleValueHeaderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/SingleValueHeaderTest.java
@@ -1,0 +1,51 @@
+package io.micronaut.http.server.tck.lambda.tests;
+
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpStatus;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.tck.AssertionUtils;
+import io.micronaut.http.tck.BodyAssertion;
+import io.micronaut.http.tck.HttpResponseAssertion;
+import org.junit.jupiter.api.Test;
+import java.io.IOException;
+
+import static io.micronaut.http.tck.TestScenario.asserts;
+
+public class SingleValueHeaderTest {
+    private static final String SPEC_NAME = "SingleValueHeaderTest";
+
+    @Test
+    void noHeaderSent() throws IOException {
+        asserts(SPEC_NAME,
+                HttpRequest.GET("/single-value-header").accept(MediaType.TEXT_PLAIN),
+                (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                        .status(HttpStatus.OK)
+                        .body(BodyAssertion.builder().body("HEADER NOT DEFINED").equals())
+                        .build()));
+    }
+
+    @Test
+    void headerSent() throws IOException {
+        asserts(SPEC_NAME,
+                HttpRequest.GET("/single-value-header").accept(MediaType.TEXT_PLAIN).header("sample-header", "sample-value"),
+                (server, request) -> AssertionUtils.assertDoesNotThrow(server, request, HttpResponseAssertion.builder()
+                        .status(HttpStatus.OK)
+                        .body(BodyAssertion.builder().body("sample-value").equals())
+                        .build()));
+    }
+
+    @Requires(property = "spec.name", value = SPEC_NAME)
+    @Controller
+    static class SampleController {
+
+        @Produces(MediaType.TEXT_PLAIN)
+        @Get("/single-value-header")
+        String singleValueHeader(HttpRequest<?> request) {
+            return request.getHeaders().get("sample-header", String.class).orElse("HEADER NOT DEFINED");
+        }
+    }
+}


### PR DESCRIPTION
…e used

Close: #1928 #1942

Collapse single and multi-value headers as described in the AWS Lambda Docs:

> The headers key can only contain single-value headers.
> The multiValueHeaders key can contain multi-value headers as well as single-value headers.
> If you specify values for both headers and multiValueHeaders, API Gateway merges them into a single list. If the same key-value pair is
> specified in both, only the values from multiValueHeaders will appear in the merged list.

In a production scenario, both multi and single are present, but I can see the appeal of specifying only one in a test.