### PR TITLE
Add test for issue 2056

### DIFF
--- a/test-suite-aws-lambda-events-serde/build.gradle.kts
+++ b/test-suite-aws-lambda-events-serde/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 dependencies {
     testImplementation(projects.testSuiteAwsLambdaEvents)
+    testImplementation(projects.micronautFunctionAwsApiProxy)
     testImplementation(mnSerde.micronaut.serde.jackson)
     testImplementation(projects.micronautAwsLambdaEventsSerde)
 }

--- a/test-suite-aws-lambda-events-serde/src/test/java/io/micronaut/aws/lambda/events/serde/tests/Issue2056Test.java
+++ b/test-suite-aws-lambda-events-serde/src/test/java/io/micronaut/aws/lambda/events/serde/tests/Issue2056Test.java
@@ -1,0 +1,37 @@
+package io.micronaut.aws.lambda.events.serde.tests;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import io.micronaut.function.aws.proxy.MockLambdaContext;
+import io.micronaut.function.aws.proxy.payload1.ApiGatewayProxyRequestEventFunction;
+import io.micronaut.http.HttpMethod;
+import io.micronaut.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Issue2056Test {
+
+    private ApiGatewayProxyRequestEventFunction handler;
+
+    @BeforeEach
+    void setupSpec() {
+        handler = new ApiGatewayProxyRequestEventFunction();
+    }
+
+    @AfterEach
+    void cleanupSpec() throws Exception {
+        handler.close();
+    }
+
+    @Test
+    void testNotFoundEncoding() {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        request.setPath("/not_a_valid_url");
+        request.setHttpMethod(HttpMethod.GET.toString());
+        var response = handler.handleRequest(request, new MockLambdaContext());
+
+        assertEquals(HttpStatus.NOT_FOUND.getCode(), response.getStatusCode());
+    }
+}


### PR DESCRIPTION
When we add back `@SerdeImport(Object.class)` to aws-lambda-events-serde/src/main/java/io/micronaut/aws/lambda/events/serde/LambdaDestinationEventSerde.java, this test fails.