### PR TITLE
fix: CustomPojoSerializer adds lambda events pkg

### DIFF
--- a/aws-lambda-events-serde/build.gradle.kts
+++ b/aws-lambda-events-serde/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation(projects.micronautFunctionAws)
     annotationProcessor(mnSerde.micronaut.serde.processor)
     api(mnSerde.micronaut.serde.api)
     api(libs.managed.aws.lambda.events)

--- a/aws-lambda-events-serde/src/main/java/io/micronaut/aws/lambda/events/serde/SerdeCustomPojoSerializer.java
+++ b/aws-lambda-events-serde/src/main/java/io/micronaut/aws/lambda/events/serde/SerdeCustomPojoSerializer.java
@@ -18,6 +18,7 @@ package io.micronaut.aws.lambda.events.serde;
 import com.amazonaws.services.lambda.runtime.CustomPojoSerializer;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.function.aws.JsonMapperCustomPojoSerializer;
+import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.ObjectMapper;
 
 import java.util.Collections;
@@ -33,12 +34,9 @@ public class SerdeCustomPojoSerializer extends JsonMapperCustomPojoSerializer {
 
     private static final String PACKAGE_IO_MICRONAUT_AWS_LAMBDA_EVENTS_SERDE = "io.micronaut.aws.lambda.events.serde";
 
-    public SerdeCustomPojoSerializer() {
-        this.jsonMapper = instantiateObjectMapper();
-    }
-
+    @Override
     @NonNull
-    protected ObjectMapper instantiateObjectMapper() {
+    protected JsonMapper createDefault() {
         return ObjectMapper.create(Collections.emptyMap(), PACKAGE_IO_MICRONAUT_AWS_LAMBDA_EVENTS_SERDE);
     }
 

--- a/aws-lambda-events-serde/src/main/java/io/micronaut/aws/lambda/events/serde/SerdeCustomPojoSerializer.java
+++ b/aws-lambda-events-serde/src/main/java/io/micronaut/aws/lambda/events/serde/SerdeCustomPojoSerializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.aws.lambda.events.serde;
+
+import com.amazonaws.services.lambda.runtime.CustomPojoSerializer;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.function.aws.JsonMapperCustomPojoSerializer;
+import io.micronaut.serde.ObjectMapper;
+
+import java.util.Collections;
+
+/**
+ * Provides an implementation of {@link CustomPojoSerializer} which is loaded via SPI.
+ * This implementation avoids paying a double hit on performance when using a serialization library inside the Lambda function.
+ * This implementations adds the package {@value #PACKAGE_IO_MICRONAUT_AWS_LAMBDA_EVENTS_SERDE} which contains {@link io.micronaut.serde.annotation.SerdeImport} for the AWS Lambda Events classes to the ObjectMapper creation.
+ * @author Sergio del Amo
+ * @since 4.0.0
+ */
+public class SerdeCustomPojoSerializer extends JsonMapperCustomPojoSerializer {
+
+    private static final String PACKAGE_IO_MICRONAUT_AWS_LAMBDA_EVENTS_SERDE = "io.micronaut.aws.lambda.events.serde";
+
+    public SerdeCustomPojoSerializer() {
+        this.jsonMapper = instantiateObjectMapper();
+    }
+
+    @NonNull
+    protected ObjectMapper instantiateObjectMapper() {
+        return ObjectMapper.create(Collections.emptyMap(), PACKAGE_IO_MICRONAUT_AWS_LAMBDA_EVENTS_SERDE);
+    }
+
+}

--- a/aws-lambda-events-serde/src/main/resources/META-INF/services/com.amazonaws.services.lambda.runtime.CustomPojoSerializer
+++ b/aws-lambda-events-serde/src/main/resources/META-INF/services/com.amazonaws.services.lambda.runtime.CustomPojoSerializer
@@ -1,1 +1,1 @@
-io.micronaut.function.aws.JsonMapperCustomPojoSerializer
+io.micronaut.aws.lambda.events.serde.SerdeCustomPojoSerializer

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayCustomAuthorizerEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayCustomAuthorizerEventSpec.groovy
@@ -17,19 +17,13 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class APIGatewayCustomAuthorizerEventSpec extends Specification {
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "APIGatewayCustomAuthorizerEvent can be serialized"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayCustomAuthorizerEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayCustomAuthorizerEventSpec.groovy
@@ -1,29 +1,12 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class APIGatewayCustomAuthorizerEventSpec extends Specification {
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "APIGatewayCustomAuthorizerEvent can be serialized"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayProxyRequestEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayProxyRequestEventSpec.groovy
@@ -5,16 +5,13 @@ import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class APIGatewayProxyRequestEventSpec extends Specification {
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
-
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    
     void "APIGatewayProxyRequestEvent can be serialized"() {
         given:
         File f = new File("src/test/resources/api-gateway-proxy.json")

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayProxyRequestEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/APIGatewayProxyRequestEventSpec.groovy
@@ -1,17 +1,13 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
-import io.micronaut.context.BeanContext
-import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class APIGatewayProxyRequestEventSpec extends Specification {
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
-    
+
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
+
     void "APIGatewayProxyRequestEvent can be serialized"() {
         given:
         File f = new File("src/test/resources/api-gateway-proxy.json")

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/AllAwsLambdaEventsSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/AllAwsLambdaEventsSpec.groovy
@@ -19,7 +19,6 @@ package io.micronaut.aws.lambda.events.serde
 import com.amazonaws.services.lambda.runtime.events.*
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord
-import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification
 import com.amazonaws.services.lambda.runtime.serialization.events.LambdaEventSerializers
 import com.amazonaws.services.lambda.runtime.serialization.events.mixins.*
 import com.amazonaws.services.lambda.runtime.serialization.events.modules.DateModule

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudFrontSimpleRemoteCallSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudFrontSimpleRemoteCallSpec.groovy
@@ -1,29 +1,12 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CloudFrontEvent
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class CloudFrontSimpleRemoteCallSpec extends Specification {
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "test deserialization of cloudfront simple remote call event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudFrontSimpleRemoteCallSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudFrontSimpleRemoteCallSpec.groovy
@@ -17,20 +17,13 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CloudFrontEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class CloudFrontSimpleRemoteCallSpec extends Specification {
-
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "test deserialization of cloudfront simple remote call event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudWatchLogsEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudWatchLogsEventSpec.groovy
@@ -1,20 +1,14 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CloudWatchLogsEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class CloudWatchLogsEventSpec extends Specification {
 
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "test deserialization of cloud watch scheduled event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudWatchLogsEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CloudWatchLogsEventSpec.groovy
@@ -1,14 +1,12 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CloudWatchLogsEvent
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class CloudWatchLogsEventSpec extends Specification {
 
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "test deserialization of cloud watch scheduled event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CodeCommitRepositoryEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CodeCommitRepositoryEventSpec.groovy
@@ -17,22 +17,16 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CodeCommitEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class CodeCommitRepositoryEventSpec extends Specification {
 
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "test deserialization of cloud watch scheduled event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CodeCommitRepositoryEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CodeCommitRepositoryEventSpec.groovy
@@ -1,32 +1,14 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CodeCommitEvent
-import io.micronaut.serde.ObjectMapper
+import io.micronaut.json.JsonMapper
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
-import spock.lang.Shared
 import spock.lang.Specification
 
 class CodeCommitRepositoryEventSpec extends Specification {
 
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "test deserialization of cloud watch scheduled event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CognitoEventSerdeSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CognitoEventSerdeSpec.groovy
@@ -1,30 +1,12 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.CognitoEvent
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class CognitoEventSerdeSpec extends Specification {
 
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "test deserialization of cloud watch scheduled event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CognitoEventSerdeSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CognitoEventSerdeSpec.groovy
@@ -16,22 +16,15 @@
 
 package io.micronaut.aws.lambda.events.serde
 
-
 import com.amazonaws.services.lambda.runtime.events.CognitoEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class CognitoEventSerdeSpec extends Specification {
 
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "test deserialization of cloud watch scheduled event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CustomPojoSerializerUtils.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CustomPojoSerializerUtils.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.CustomPojoSerializer
+import io.micronaut.json.JsonMapper
 import io.micronaut.serde.ObjectMapper
 
 import javax.naming.ConfigurationException
@@ -21,11 +22,11 @@ class CustomPojoSerializerUtils {
                 .orElseThrow(() -> new RuntimeException("No CustomPojoSerializer found"))
     }
 
-    static ObjectMapper getObjectMapper() {
-        CustomPojoSerializer pojoSerializer = CustomPojoSerializerUtils.customPojoSerializer()
+    static JsonMapper getJsonMapper() {
+        CustomPojoSerializer pojoSerializer = customPojoSerializer()
         if (pojoSerializer instanceof SerdeCustomPojoSerializer) {
-            return  ((SerdeCustomPojoSerializer) pojoSerializer).getJsonMapper()
+            return pojoSerializer.jsonMapper
         }
-        throw new ConfigurationException("CustomPojoSerializer no type of SerdeCustomPojoSerializer")
+        throw new ConfigurationException("CustomPojoSerializer is not a type of SerdeCustomPojoSerializer")
     }
 }

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CustomPojoSerializerUtils.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/CustomPojoSerializerUtils.groovy
@@ -1,0 +1,31 @@
+package io.micronaut.aws.lambda.events.serde
+
+import com.amazonaws.services.lambda.runtime.CustomPojoSerializer
+import io.micronaut.serde.ObjectMapper
+
+import javax.naming.ConfigurationException
+
+class CustomPojoSerializerUtils {
+
+    private static List<CustomPojoSerializer> customPojoSerializers() {
+        List<CustomPojoSerializer> services = new ArrayList<>()
+        ServiceLoader<CustomPojoSerializer> loader = ServiceLoader.load(CustomPojoSerializer.class)
+        loader.forEach(services::add)
+        return services
+    }
+
+    static CustomPojoSerializer customPojoSerializer() {
+        return customPojoSerializers()
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("No CustomPojoSerializer found"))
+    }
+
+    static ObjectMapper getObjectMapper() {
+        CustomPojoSerializer pojoSerializer = CustomPojoSerializerUtils.customPojoSerializer()
+        if (pojoSerializer instanceof SerdeCustomPojoSerializer) {
+            return  ((SerdeCustomPojoSerializer) pojoSerializer).getJsonMapper()
+        }
+        throw new ConfigurationException("CustomPojoSerializer no type of SerdeCustomPojoSerializer")
+    }
+}

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/DynamodbEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/DynamodbEventSpec.groovy
@@ -17,20 +17,14 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class DynamodbEventSpec extends Specification {
 
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "test deserialization of sqs recieve message event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/DynamodbEventSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/DynamodbEventSpec.groovy
@@ -1,30 +1,12 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class DynamodbEventSpec extends Specification {
 
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "test deserialization of sqs recieve message event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/S3EventNotificationSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/S3EventNotificationSpec.groovy
@@ -2,20 +2,14 @@ package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
-import spock.lang.PendingFeature
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class S3EventNotificationSpec extends Specification {
-    @Inject
-    ObjectMapper objectMapper
 
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "S3EventNotification can be serialized with s3-put"() {
         given:
@@ -48,7 +42,7 @@ class S3EventNotificationSpec extends Specification {
 
         when:
         String json = f.text
-        S3EventNotification event = objectMapper.readValue(json, S3EventNotification)
+        S3EventNotification event = getObjectMapper().readValue(json, S3EventNotification)
 
         then:
         assertionsS3Event(event)
@@ -63,7 +57,7 @@ class S3EventNotificationSpec extends Specification {
 
         when:
         String json = f.text
-        S3Event event = objectMapper.readValue(json, S3Event)
+        S3Event event = getObjectMapper().readValue(json, S3Event)
 
         then:
         assertionsS3Put(event)
@@ -78,7 +72,7 @@ class S3EventNotificationSpec extends Specification {
 
         when:
         String json = f.text
-        S3Event event = objectMapper.readValue(json, S3Event)
+        S3Event event = getObjectMapper().readValue(json, S3Event)
 
         then:
         assertionsS3Event(event)

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/S3EventNotificationSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/S3EventNotificationSpec.groovy
@@ -2,14 +2,14 @@ package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification
-import io.micronaut.serde.ObjectMapper
+import io.micronaut.json.JsonMapper
 import spock.lang.Shared
 import spock.lang.Specification
 
 class S3EventNotificationSpec extends Specification {
 
     @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "S3EventNotification can be serialized with s3-put"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SQSReceiveMessageSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SQSReceiveMessageSpec.groovy
@@ -1,30 +1,12 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class SQSReceiveMessageSpec extends Specification {
 
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "test deserialization of sqs recieve message event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SQSReceiveMessageSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SQSReceiveMessageSpec.groovy
@@ -17,20 +17,14 @@
 package io.micronaut.aws.lambda.events.serde
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class SQSReceiveMessageSpec extends Specification {
 
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "test deserialization of sqs recieve message event"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SerializeMapsAndCollectionsSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SerializeMapsAndCollectionsSpec.groovy
@@ -1,29 +1,11 @@
-/*
- * Copyright 2022 original authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package io.micronaut.aws.lambda.events.serde
 
-import io.micronaut.serde.ObjectMapper
-import spock.lang.Shared
+import io.micronaut.json.JsonMapper
 import spock.lang.Specification
 
 class SerializeMapsAndCollectionsSpec extends Specification {
 
-    @Shared
-    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
+    JsonMapper objectMapper = CustomPojoSerializerUtils.getJsonMapper()
 
     void "Serialize map with values that are of type ArrayList"() {
         given:

--- a/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SerializeMapsAndCollectionsSpec.groovy
+++ b/aws-lambda-events-serde/src/test/groovy/io/micronaut/aws/lambda/events/serde/SerializeMapsAndCollectionsSpec.groovy
@@ -16,20 +16,14 @@
 
 package io.micronaut.aws.lambda.events.serde
 
-import io.micronaut.context.BeanContext
 import io.micronaut.serde.ObjectMapper
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
+import spock.lang.Shared
 import spock.lang.Specification
 
-@MicronautTest(startApplication = false)
 class SerializeMapsAndCollectionsSpec extends Specification {
 
-    @Inject
-    ObjectMapper objectMapper
-
-    @Inject
-    BeanContext beanContext
+    @Shared
+    ObjectMapper objectMapper = CustomPojoSerializerUtils.getObjectMapper()
 
     void "Serialize map with values that are of type ArrayList"() {
         given:

--- a/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
@@ -37,14 +37,17 @@ import java.util.stream.Stream;
 public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
     protected JsonMapper jsonMapper;
 
-    @Deprecated(forRemoval = true, since = "4.4.3")
     public JsonMapperCustomPojoSerializer() {
         this.jsonMapper = createDefault();
     }
 
-    @Deprecated(forRemoval = true, since = "4.4.3")
+    /**
+     *
+     * @return A JsonMapper
+     */
     // https://github.com/micronaut-projects/micronaut-core/pull/9445
-    private @NonNull JsonMapper createDefault() {
+    @NonNull
+    protected JsonMapper createDefault() {
         return ServiceLoader.load(JsonMapperSupplier.class).stream()
             .flatMap(p -> {
                 try {
@@ -66,6 +69,10 @@ public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
             .orElseThrow(() -> new IllegalStateException("No JsonMapper implementation found"));
     }
 
+    /**
+     *
+     * @return The Json Mapper
+     */
     public JsonMapper getJsonMapper() {
         return jsonMapper;
     }

--- a/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
+++ b/function-aws/src/main/java/io/micronaut/function/aws/JsonMapperCustomPojoSerializer.java
@@ -35,12 +35,14 @@ import java.util.stream.Stream;
  * @since 4.0.0
  */
 public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
-    private JsonMapper jsonMapper;
+    protected JsonMapper jsonMapper;
 
+    @Deprecated(forRemoval = true, since = "4.4.3")
     public JsonMapperCustomPojoSerializer() {
         this.jsonMapper = createDefault();
     }
 
+    @Deprecated(forRemoval = true, since = "4.4.3")
     // https://github.com/micronaut-projects/micronaut-core/pull/9445
     private @NonNull JsonMapper createDefault() {
         return ServiceLoader.load(JsonMapperSupplier.class).stream()
@@ -62,6 +64,10 @@ public class JsonMapperCustomPojoSerializer implements CustomPojoSerializer {
             })
             .findFirst()
             .orElseThrow(() -> new IllegalStateException("No JsonMapper implementation found"));
+    }
+
+    public JsonMapper getJsonMapper() {
+        return jsonMapper;
     }
 
     @Override


### PR DESCRIPTION
Add a CustomPojoSerializer implementation which includes the package io.micronaut.aws.lambda.events.serde. This package contains `@SerdeImport` for the AWS Lambda Events classes.

Close: https://github.com/micronaut-projects/micronaut-aws/issues/2048