### PR TITLE
Dependency updates and apply Sonatype Scan Gradle Plugin

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,6 +58,11 @@ jobs:
         run: |
           [ -f ./setup.sh ] && ./setup.sh || [ ! -f ./setup.sh ]
 
+      - name: "🚔 Sonatype Scan"
+        id: sonatypescan
+        run: |
+          ./gradlew ossIndexAudit --no-parallel
+
       - name: "🛠 Build with Gradle"
         id: gradle
         run: |

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,6 +30,8 @@ jobs:
       PREDICTIVE_TEST_SELECTION: "${{ github.event_name == 'pull_request' && 'true' || 'false' }}"
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OSS_INDEX_USERNAME: ${{ secrets.OSS_INDEX_USERNAME }}
+      OSS_INDEX_PASSWORD: ${{ secrets.OSS_INDEX_PASSWORD }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: "🗑 Free disk space"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: "🚔 Sonatype Scan"
         id: sonatypescan
+        if: matrix.java == '17'
         run: |
           ./gradlew ossIndexAudit --no-parallel
 

--- a/aws-service-discovery/src/main/java/io/micronaut/discovery/aws/servicediscovery/registration/ServiceRegistrationStatusTask.java
+++ b/aws-service-discovery/src/main/java/io/micronaut/discovery/aws/servicediscovery/registration/ServiceRegistrationStatusTask.java
@@ -72,7 +72,7 @@ class ServiceRegistrationStatusTask implements Runnable {
             GetOperationResponse result = serviceDiscoveryClient.getOperation(
                     GetOperationRequest.builder().operationId(operationId).build()
             );
-            LOG.info("Service registration for operation {} resulted in {}", operationId, result.operation().status());
+            LOG.info("Service registration for operation {} resulted in {}", operationId, result == null || result.operation() == null ? null : result.operation().status());
             if (result.operation().status() == OperationStatus.FAIL || result.operation().status() == OperationStatus.SUCCESS) {
                 registered = true; // either way we are done
                 if (result.operation().status() == OperationStatus.FAIL) {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,4 +11,5 @@ dependencies {
     implementation libs.javapoet
     implementation libs.gradle.micronaut
     implementation libs.gradle.kotlin
+    implementation("org.sonatype.gradle.plugins:scan-gradle-plugin:2.8.3")
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation libs.javapoet
     implementation libs.gradle.micronaut
     implementation libs.gradle.kotlin
-    implementation("org.sonatype.gradle.plugins:scan-gradle-plugin:2.8.3")
+    implementation(libs.sonatype.scan)
 }

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.aws-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.aws-module.gradle
@@ -1,4 +1,23 @@
 plugins {
     id "io.micronaut.build.internal.aws-base"
     id "io.micronaut.build.internal.module"
+    id("org.sonatype.gradle.plugins.scan")
+}
+String ossIndexUsername = System.getenv("OSS_INDEX_USERNAME") ?: project.properties["ossIndexUsername"]
+String ossIndexPassword = System.getenv("OSS_INDEX_PASSWORD") ?: project.properties["ossIndexPassword"]
+boolean sonatypePluginConfigured = ossIndexUsername != null && ossIndexPassword != null
+if (sonatypePluginConfigured) {
+    ossIndexAudit {
+        username = ossIndexUsername
+        password = ossIndexPassword
+        excludeCompileOnly = true
+        excludeCoordinates = [
+                "org.eclipse.jetty:jetty-http:11.0.24" // no version of Jetty 11 patched https://ossindex.sonatype.org/component/pkg:maven/org.eclipse.jetty/jetty-http
+        ]
+    }
+}
+configurations.all {
+    resolutionStrategy {
+        force("commons-io:commons-io:2.14.0") // first version patched https://ossindex.sonatype.org/component/pkg:maven/commons-io/commons-io
+    }
 }

--- a/function-aws-api-proxy-test/build.gradle.kts
+++ b/function-aws-api-proxy-test/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 dependencies {
     api(mn.micronaut.http.server)
     api(projects.micronautFunctionAwsApiProxy)
+    implementation(platform(mnServlet.boms.jetty))
     implementation(libs.jetty.server)
     testImplementation(mn.micronaut.http.client)
     testImplementation(mn.micronaut.jackson.databind)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ spock = "2.3-groovy-4.0"
 
 bouncycastle = '1.70'
 fileupload = '0.0.6'
-jetty = '11.0.24'
 logback-json-classic = '0.1.5'
 
 micronaut-discovery = "4.5.0"
@@ -90,7 +89,7 @@ bouncycastle-provider = { module = 'org.bouncycastle:bcprov-jdk15on', version.re
 fileupload = { module = 'org.javadelight:delight-fileupload', version.ref = 'fileupload' }
 graal-sdk = { module = 'org.graalvm.sdk:graal-sdk', version.ref = 'graal' }
 jackson-afterburner = { module = 'com.fasterxml.jackson.module:jackson-module-afterburner' }
-jetty-server = { module = 'org.eclipse.jetty:jetty-server', version.ref = 'jetty' }
+jetty-server = { module = 'org.eclipse.jetty:jetty-server' }
 jcl-over-slf4j = { module = 'org.slf4j:jcl-over-slf4j', version.ref = 'slf4j' }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine' }
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ micronaut-starter = "3.9.2"
 slf4j = "2.0.16"
 servlet-api = "2.5"
 javapoet = "1.13.0"
+sonatype-scan = "3.0.0"
 
 # The following version should probably
 # be defined in Micronaut Graal but it's not shipped with a BOM yet
@@ -114,6 +115,8 @@ managed-awssdk-secretsmanager = { module = 'software.amazon.awssdk:secretsmanage
 managed-jcl-over-slf4j = { module = 'org.slf4j:jcl-over-slf4j', version.ref = 'slf4j' }
 
 servlet-api = { module = 'javax.servlet:servlet-api', version.ref = 'servlet-api' }
+sonatype-scan = { module = "org.sonatype.gradle.plugins:scan-gradle-plugin", version.ref = "sonatype-scan" }
+
 # Gradle
 
 gradle-micronaut = { module = "io.micronaut.gradle:micronaut-gradle-plugin", version.ref = "micronaut-gradle-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ logback-json-classic = '0.1.5'
 
 micronaut-discovery = "4.5.0"
 micronaut-groovy = "4.4.0"
-micronaut-logging = "1.4.0"
+micronaut-logging = "1.5.1"
 micronaut-mongodb = "5.5.0"
 micronaut-reactor = "3.6.0"
 micronaut-security = "4.11.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ micronaut-starter = "3.9.2"
 slf4j = "2.0.16"
 servlet-api = "2.5"
 javapoet = "1.13.0"
-sonatype-scan = "3.0.0"
+sonatype-scan = "2.8.3"
 
 # The following version should probably
 # be defined in Micronaut Graal but it's not shipped with a BOM yet

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ micronaut-validation = "4.8.0"
 
 managed-alexa-ask-sdk = "2.86.0"
 managed-aws-java-sdk-v1 = '1.12.780'
-managed-aws-java-sdk-v2 = '2.29.11'
+managed-aws-java-sdk-v2 = '2.29.39'
 managed-aws-lambda = '1.2.3'
 managed-aws-lambda-events = '3.14.0'
 managed-aws-lambda-java-serialization = '1.1.5'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.7.2"
+micronaut = "4.7.9"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.5.0"
 groovy = "4.0.22"


### PR DESCRIPTION
**Dependency Updates**

- Micronaut Core 4.7.9
- AWS SDK V2 2.29.39
- Logging 1.5.1

Don't define jetty version. Use jetty version from Micronaut-servlet. 

Apply [Sonatype Gradle Scan Plugin](https://github.com/sonatype-nexus-community/scan-gradle-plugin). 
