### PR TITLE
Add ability to override AWS endpoints during configuration discovery.

### DIFF
--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/AWSServiceConfigurationProperties.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/service/AWSServiceConfigurationProperties.java
@@ -16,6 +16,7 @@
 package io.micronaut.aws.sdk.v2.service;
 
 import io.micronaut.aws.AWSConfiguration;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.EachProperty;
 import io.micronaut.context.annotation.Parameter;
 import io.micronaut.core.annotation.NonNull;
@@ -31,6 +32,7 @@ import java.net.URISyntaxException;
  * @since 3.10.0
  *
  */
+@BootstrapContextCompatible
 @EachProperty(AWSServiceConfigurationProperties.SERVICE_PREFIX)
 public class AWSServiceConfigurationProperties implements AWSServiceConfiguration {
 

--- a/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/AWSServiceConfigurationPropertiesSpec.groovy
+++ b/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/AWSServiceConfigurationPropertiesSpec.groovy
@@ -1,0 +1,26 @@
+package io.micronaut.aws.sdk.v2
+
+import io.micronaut.aws.sdk.v2.service.AWSServiceConfigurationProperties
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.BootstrapContextCompatible
+import io.micronaut.inject.BeanDefinition
+import spock.lang.Specification
+
+class AWSServiceConfigurationPropertiesSpec extends Specification {
+    void "AWSServiceConfigurationProperties is annotated with BootstrapContextCompatible"() {
+        given:
+        Map<String, String> properties = [
+            "aws.services.ssm.endpoint-override": "http://localhost:4566"
+        ]
+        ApplicationContext applicationContext = ApplicationContext.run(properties)
+
+        when:
+        BeanDefinition<AWSServiceConfigurationProperties> beanDefinition = applicationContext.getBeanDefinition(AWSServiceConfigurationProperties)
+
+        then:
+        beanDefinition.getAnnotationNameByStereotype(BootstrapContextCompatible).isPresent()
+
+        cleanup:
+        applicationContext.close()
+    }
+}


### PR DESCRIPTION
Currently, it is not possible to override the AWS SSM/ secret manager endpoint during configuration discovery. This stops you from being able to integrate Localstack during the configuration discovery process.

I've added the BootstrapContextCompatible annotation to the AWSServiceConfigurationProperties class to resolve this.
I've also added a test to check that this annotation has been added as I have seen similar tests throughout the project.
I am not sure if additional testing showing the configuration discovery process integrating with Localstack is required.