### PR TITLE
feat(function-aws-api-proxy): add multipart/form-data support to ApiGatewayServletRequest

### DIFF
--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayBinderRegistry.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayBinderRegistry.java
@@ -18,6 +18,9 @@ package io.micronaut.function.aws.proxy;
 import io.micronaut.context.annotation.Replaces;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.function.aws.proxy.multipart.CompletedFileUploadBinder;
+import io.micronaut.function.aws.proxy.multipart.PartAnnotationRequestArgumentBinder;
+import io.micronaut.http.annotation.Part;
 import io.micronaut.http.bind.DefaultRequestBinderRegistry;
 import io.micronaut.http.bind.binders.DefaultBodyAnnotationBinder;
 import io.micronaut.http.bind.binders.RequestArgumentBinder;
@@ -39,5 +42,8 @@ class ApiGatewayBinderRegistry<T> extends ServletBinderRegistry<T> {
         DefaultBodyAnnotationBinder<T> defaultBodyAnnotationBinder
     ) {
         super(mediaTypeCodecRegistry, conversionService, binders, defaultBodyAnnotationBinder);
+
+        CompletedFileUploadBinder completedFileUploadBinder = new CompletedFileUploadBinder();
+        byAnnotation.put(Part.class, new PartAnnotationRequestArgumentBinder<>(conversionService, completedFileUploadBinder));
     }
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -29,6 +29,7 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.core.util.SupplierUtil;
+import io.micronaut.function.aws.proxy.multipart.MultipartDataDecoder;
 import io.micronaut.http.CaseInsensitiveMutableHttpHeaders;
 import io.micronaut.http.FullHttpRequest;
 import io.micronaut.http.HttpMethod;
@@ -41,6 +42,7 @@ import io.micronaut.http.body.ByteBody;
 import io.micronaut.http.body.stream.AvailableByteArrayBody;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
+import io.micronaut.http.multipart.CompletedFileUpload;
 import io.micronaut.http.uri.UriBuilder;
 import io.micronaut.servlet.http.ByteArrayByteBuffer;
 import io.micronaut.servlet.http.MutableServletHttpRequest;
@@ -91,6 +93,8 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
     private Supplier<Optional<T>> body;
     private T parsedBody;
     private T overriddenBody;
+    private final Supplier<Optional<MultipartDataDecoder>> multipartDataDecoder;
+    private Map<String, CompletedFileUpload> fileUploads;
 
     private ByteArrayByteBuffer<T> servletByteBuffer;
 
@@ -110,6 +114,19 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
         this.body = SupplierUtil.memoizedNonEmpty(() -> {
             T built = parsedBody != null ? parsedBody :  (T) bodyBuilder.buildBody(this::getInputStream, this);
             return Optional.ofNullable(built);
+        });
+        this.multipartDataDecoder = SupplierUtil.memoized(() -> {
+            try {
+                MediaType contentType = getContentType().orElse(null);
+                if (MediaType.MULTIPART_FORM_DATA_TYPE.equals(contentType)) {
+                    return Optional.of(new MultipartDataDecoder(getBodyBytes(), getHeaders(), getCharacterEncoding()));
+                }
+            } catch (IOException e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error decoding multipart form data: {}", e.getMessage(), e);
+                }
+            }
+            return Optional.empty();
         });
     }
 
@@ -266,14 +283,36 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
      */
     protected MapListOfStringAndMapStringMutableHttpParameters getParametersFromBody(Map<String, String> queryStringParameters) {
         Map<String, List<String>> parameters = null;
-        try {
-            parameters = new QueryStringDecoder(new String(getBodyBytes(), getCharacterEncoding()), false).parameters();
-        } catch (IOException ex) {
-            if (log.isDebugEnabled()) {
-                log.debug("Error decoding form data: " + ex.getMessage(), ex);
+        MediaType contentType = getContentType().orElse(MediaType.APPLICATION_JSON_TYPE);
+
+        if (MediaType.APPLICATION_FORM_URLENCODED_TYPE.equals(contentType)) {
+            try {
+                parameters = new QueryStringDecoder(new String(getBodyBytes(), getCharacterEncoding()), false).parameters();
+            } catch (IOException ex) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Error decoding form data: {}", ex.getMessage(), ex);
+                }
             }
+        } else if (MediaType.MULTIPART_FORM_DATA_TYPE.equals(contentType)) {
+            parameters = multipartDataDecoder.get()
+                .map(MultipartDataDecoder::parameters)
+                .orElse(Collections.emptyMap());
         }
+
         return new MapListOfStringAndMapStringMutableHttpParameters(conversionService, parameters, queryStringParameters);
+    }
+
+    /**
+     * Gets a map of uploaded files from the multipart request.
+     * @return A map of field names to file uploads
+     */
+    public Map<String, CompletedFileUpload> getFileUploads() {
+        if (fileUploads != null) {
+            log.trace("Skipping decoding file uploads as they have already been processed");
+        } else {
+            fileUploads = multipartDataDecoder.get().map(MultipartDataDecoder::fileUploads).orElse(Collections.emptyMap());
+        }
+        return Collections.unmodifiableMap(fileUploads);
     }
 
     @Override
@@ -355,6 +394,7 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
         Map<String, List<String>> multi = multiQueryStringParametersSupplier.get();
         Map<String, String> single = queryStringParametersSupplier.get();
         MediaType mediaType = getContentType().orElse(MediaType.APPLICATION_JSON_TYPE);
+
         if (isFormSubmission(mediaType)) {
             return getParametersFromBody(MapCollapseUtils.collapse(MapCollapseUtils.collapse(multi, single)));
         } else {

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/CompletedFileUploadBinder.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/CompletedFileUploadBinder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.multipart;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.type.Argument;
+import io.micronaut.function.aws.proxy.ApiGatewayServletRequest;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.bind.binders.TypedRequestArgumentBinder;
+import io.micronaut.http.multipart.CompletedFileUpload;
+
+import java.util.Optional;
+
+/**
+ * Binds {@link CompletedFileUpload} arguments from multipart requests in the AWS API Gateway context.
+ */
+@Internal
+public class CompletedFileUploadBinder implements TypedRequestArgumentBinder<CompletedFileUpload> {
+
+    static final Argument<CompletedFileUpload> TYPE = Argument.of(CompletedFileUpload.class);
+
+    @Override
+    public Argument<CompletedFileUpload> argumentType() {
+        return TYPE;
+    }
+
+    @Override
+    public BindingResult<CompletedFileUpload> bind(
+            ArgumentConversionContext<CompletedFileUpload> context,
+            HttpRequest<?> source) {
+
+        if (!(source instanceof ApiGatewayServletRequest)) {
+            return BindingResult.UNSATISFIED;
+        }
+
+        ApiGatewayServletRequest<?, ?, ?> request = (ApiGatewayServletRequest<?, ?, ?>) source;
+
+        // Get the parameter name to bind
+        String paramName = context.getArgument()
+                .getAnnotationMetadata()
+                .stringValue(Bindable.class)
+                .orElse(context.getArgument().getName());
+
+        // Try to find a file upload with the matching name
+        final CompletedFileUpload fileUpload = request.getFileUploads().get(paramName);
+        if (fileUpload != null) {
+            return () -> Optional.of(fileUpload);
+        }
+
+        return BindingResult.UNSATISFIED;
+    }
+}

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/MultipartDataDecoder.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/MultipartDataDecoder.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.multipart;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.http.HttpHeaders;
+import io.micronaut.http.multipart.CompletedFileUpload;
+
+import java.nio.charset.Charset;
+import java.util.*;
+
+/**
+ * Decodes multipart/form-data content from an HTTP request body into parameters (plaintext fields)
+ * and uploads (binary data fields).
+ */
+@Internal
+public final class MultipartDataDecoder {
+    private static final String BOUNDARY_KEYWORD = "boundary=";
+    private static final String CONTENT_DISPOSITION_HEADER = "content-disposition:";
+    private static final String CONTENT_TYPE_HEADER = "content-type:";
+    private static final String FILENAME_HEADER = "filename=";
+    private static final String NAME_HEADER = "name=";
+    private static final String CRLF = "\r\n";
+    private static final String HEADER_END_MARKER = CRLF + CRLF;
+    private final byte[] bodyBytes;
+    private final String boundary;
+    private final Charset charset;
+    private Map<String, List<String>> params;
+    private Map<String, CompletedFileUpload> fileUploads;
+
+    /**
+     * Creates a new decoder for multipart/form-data content.
+     *
+     * @param bodyBytes The raw request body as a byte array
+     * @param httpHeaders The HTTP headers of the request.
+     * @param charset The charset to use for text content
+     */
+    public MultipartDataDecoder(byte[] bodyBytes, HttpHeaders httpHeaders, Charset charset) {
+        this.bodyBytes = bodyBytes;
+        this.charset = charset;
+        String contentType = httpHeaders.getContentType().orElse(null);
+
+        this.boundary = contentType != null ? MultipartDataDecoder.extractBoundary(contentType) : "";
+    }
+
+    /**
+     * Extract the boundary from a Content-Type header.
+     * @param contentType The Content-Type header value
+     * @return The boundary string or null if not found
+     */
+    private static String extractBoundary(String contentType) {
+        int boundaryIndex = contentType.indexOf(BOUNDARY_KEYWORD);
+        if (boundaryIndex > 0) {
+            String boundary = contentType.substring(boundaryIndex + BOUNDARY_KEYWORD.length());
+            // Handle quoted boundaries
+            if (boundary.startsWith("\"") && boundary.endsWith("\"")) {
+                boundary = boundary.substring(1, boundary.length() - 1);
+            }
+            // Handle additional parameters after boundary
+            int paramSeparator = boundary.indexOf(';');
+            if (paramSeparator > 0) {
+                boundary = boundary.substring(0, paramSeparator);
+            }
+            return boundary;
+        }
+        return null;
+    }
+
+    /**
+     * Returns the decoded form parameters from the multipart content.
+     * @return A map of parameter names to values
+     */
+    public Map<String, List<String>> parameters() {
+        if (params == null) {
+            parseMultipartData();
+        }
+        return params;
+    }
+
+    /**
+     * Returns the decoded file uploads from the multipart content.
+     * @return A map of field names to file uploads
+     */
+    public Map<String, CompletedFileUpload> fileUploads() {
+        if (fileUploads == null) {
+            parseMultipartData();
+        }
+        return fileUploads;
+    }
+
+    /**
+     * Extract the Content-Type from the headers of a multipart part.
+     * @param headers The headers section of a multipart part
+     * @return The content type or null if not found
+     */
+    private static String extractContentType(String headers) {
+        String lowerHeaders = headers.toLowerCase();
+        int ctIndex = lowerHeaders.indexOf(CONTENT_TYPE_HEADER);
+        if (ctIndex < 0) {
+            return null;
+        }
+
+        // Find the end of the header line
+        int lineEnd = headers.indexOf(CRLF, ctIndex);
+        if (lineEnd < 0) {
+            lineEnd = headers.length();
+        }
+
+        // Extract the value part
+        return headers.substring(ctIndex + CONTENT_TYPE_HEADER.length(), lineEnd).trim();
+    }
+
+    /**
+     * Extract the filename from the Content-Disposition header.
+     * @param multipartHeaders The headers section of a multipart part
+     * @return The filename or null if not found
+     */
+    private static String extractFilename(String multipartHeaders) {
+        String lowerHeaders = multipartHeaders.toLowerCase();
+        // We can just skip over the content disposition header here; it's mainly for browsers
+        int cdIndex = lowerHeaders.indexOf(CONTENT_DISPOSITION_HEADER);
+        if (cdIndex < 0) {
+            return null;
+        }
+
+        int filenameIndex = lowerHeaders.indexOf(FILENAME_HEADER, cdIndex);
+        if (filenameIndex < 0) {
+            return null;
+        }
+
+        // Extract the value (handling quotes)
+        filenameIndex += FILENAME_HEADER.length();
+        char quote = multipartHeaders.charAt(filenameIndex);
+        if (quote == '"' || quote == '\'') {
+            int endQuoteIndex = multipartHeaders.indexOf(quote, filenameIndex + 1);
+            if (endQuoteIndex > 0) {
+                return multipartHeaders.substring(filenameIndex + 1, endQuoteIndex);
+            }
+        } else {
+            // Unquoted filename - ends at next space or semicolon
+            int endIndex = -1;
+            for (int i = filenameIndex; i < multipartHeaders.length(); i++) {
+                char c = multipartHeaders.charAt(i);
+                if (c == ' ' || c == ';' || c == '\r' || c == '\n') {
+                    endIndex = i;
+                    break;
+                }
+            }
+            if (endIndex > 0) {
+                return multipartHeaders.substring(filenameIndex, endIndex);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the field name from the headers of a multipart part.
+     * @param multipartHeaders The headers section of a multipart part
+     * @return The field name or null if not found
+     */
+    private static String extractFieldName(String multipartHeaders) {
+        int cdIndex = -1;
+        String lowerHeaders = multipartHeaders.toLowerCase();
+        int contentDispIndex = lowerHeaders.indexOf(CONTENT_DISPOSITION_HEADER);
+        if (contentDispIndex >= 0) {
+            cdIndex = contentDispIndex;
+        }
+
+        if (cdIndex < 0) {
+            return null;
+        }
+
+        // Find the name parameter (case-insensitive)
+        int nameIndex = lowerHeaders.indexOf(NAME_HEADER, cdIndex);
+        if (nameIndex < 0) {
+            return null;
+        }
+
+        // Extract the value (handling quotes)
+        nameIndex += NAME_HEADER.length();
+        char quote = multipartHeaders.charAt(nameIndex);
+        if (quote == '"' || quote == '\'') {
+            int endQuoteIndex = multipartHeaders.indexOf(quote, nameIndex + 1);
+            if (endQuoteIndex > 0) {
+                return multipartHeaders.substring(nameIndex + 1, endQuoteIndex);
+            }
+        } else {
+            // Unquoted name - ends at next space or semicolon
+            int endIndex = -1;
+            for (int i = nameIndex; i < multipartHeaders.length(); i++) {
+                char c = multipartHeaders.charAt(i);
+                if (c == ' ' || c == ';' || c == '\r' || c == '\n') {
+                    endIndex = i;
+                    break;
+                }
+            }
+            if (endIndex > 0) {
+                return multipartHeaders.substring(nameIndex, endIndex);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse multipart/form-data content.
+     */
+    private void parseMultipartData() {
+        Map<String, List<String>> parameters = new HashMap<>();
+        Map<String, CompletedFileUpload> uploads = new LinkedHashMap<>();
+
+        if (bodyBytes == null || bodyBytes.length == 0 || boundary.isEmpty()) {
+            this.params = Collections.emptyMap();
+            this.fileUploads = Collections.emptyMap();
+            return;
+        }
+
+        // We need to find the boundary markers in the byte array directly
+        // to preserve binary data integrity
+        byte[] boundaryBytes = ("--" + boundary).getBytes(charset);
+
+        // Find all boundary positions
+        List<Integer> boundaryPositions = findByteSequence(bodyBytes, boundaryBytes);
+
+        // Process each part
+        for (int i = 0; i < boundaryPositions.size() - 1; i++) {
+            int start = boundaryPositions.get(i) + boundaryBytes.length;
+            int end = boundaryPositions.get(i + 1);
+
+            // Skip empty parts
+            if (end - start <= 4) {
+                continue;
+            }
+
+            // Extract part content
+            byte[] partBytes = new byte[end - start];
+            System.arraycopy(bodyBytes, start, partBytes, 0, partBytes.length);
+
+            // Find headers and content boundary
+            int headerEnd = findFirstByteSequence(partBytes, HEADER_END_MARKER.getBytes(charset));
+            if (headerEnd < 0) {
+                continue;
+            }
+
+            // Extract headers as a string
+            String multipartHeaders = new String(partBytes, 0, headerEnd, charset);
+
+            // Extract the name from Content-Disposition header
+            String name = extractFieldName(multipartHeaders);
+            if (name == null) {
+                continue;
+            }
+
+            // Extract content type from headers
+            String contentType = extractContentType(multipartHeaders);
+
+            // Skip past the header end marker
+            int contentStart = headerEnd + HEADER_END_MARKER.length();
+            int contentLength = partBytes.length - contentStart;
+
+            // Skip empty content
+            if (contentLength <= 0) {
+                continue;
+            }
+
+            // Trim trailing CRLF if present
+            if (contentLength >= 2 && partBytes[contentStart + contentLength - 2] == '\r' &&
+                partBytes[contentStart + contentLength - 1] == '\n') {
+                contentLength -= 2;
+            }
+
+            // Check if this is a file upload
+            boolean isFile = multipartHeaders.contains(FILENAME_HEADER);
+
+            if (isFile) {
+                // Extract filename from headers
+                String filename = extractFilename(multipartHeaders);
+                if (filename != null) {
+                    // Create byte array for file content
+                    byte[] fileContent = new byte[contentLength];
+                    System.arraycopy(partBytes, contentStart, fileContent, 0, contentLength);
+
+                    // Create a file upload object and store it
+                    SimpleCompletedFileUpload fileUpload = new SimpleCompletedFileUpload(name, filename, contentType, fileContent);
+                    uploads.put(name, fileUpload);
+                }
+            } else {
+                // For regular form fields, convert to string and add to parameters
+                String content = new String(partBytes, contentStart, contentLength, charset);
+                parameters.computeIfAbsent(name, k -> new ArrayList<>()).add(content);
+            }
+        }
+
+        this.params = parameters;
+        this.fileUploads = uploads;
+    }
+
+    /**
+     * Find all occurrences of a byte sequence within a larger byte array.
+     * @param data The data to search in
+     * @param sequence The sequence to find
+     * @return A list of starting positions for each occurrence
+     */
+    private static List<Integer> findByteSequence(byte[] data, byte[] sequence) {
+        List<Integer> positions = new ArrayList<>();
+
+        // Handle empty data or sequence
+        if (data == null || sequence == null || data.length == 0 || sequence.length == 0 ||
+            data.length < sequence.length) {
+            return positions;
+        }
+
+        // Find all occurrences
+        outer:
+        for (int i = 0; i <= data.length - sequence.length; i++) {
+            for (int j = 0; j < sequence.length; j++) {
+                if (data[i + j] != sequence[j]) {
+                    continue outer;
+                }
+            }
+            positions.add(i);
+        }
+
+        return positions;
+    }
+
+    /**
+     * Find the first occurrence of a byte sequence within a larger byte array.
+     * @param data The data to search in
+     * @param sequence The sequence to find
+     * @return The starting position or -1 if not found
+     */
+    private static int findFirstByteSequence(byte[] data, byte[] sequence) {
+        // Handle empty data or sequence
+        if (data == null || sequence == null || data.length == 0 || sequence.length == 0 ||
+            data.length < sequence.length) {
+            return -1;
+        }
+
+        // Find first occurrence
+        outer:
+        for (int i = 0; i <= data.length - sequence.length; i++) {
+            for (int j = 0; j < sequence.length; j++) {
+                if (data[i + j] != sequence[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+
+        return -1;
+    }
+}

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/PartAnnotationRequestArgumentBinder.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/PartAnnotationRequestArgumentBinder.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.multipart;
+
+import io.micronaut.core.bind.annotation.AbstractArgumentBinder;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.type.Argument;
+import io.micronaut.function.aws.proxy.ApiGatewayServletRequest;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.annotation.Part;
+import io.micronaut.http.bind.binders.AnnotatedRequestArgumentBinder;
+
+/**
+ * Binds method parameters annotated with {@link Part} to values from multipart requests.
+ * This implementation handles both regular form fields and file uploads from the
+ * {@link ApiGatewayServletRequest}.
+ *
+ * @param <T> the type parameter
+ */
+public class PartAnnotationRequestArgumentBinder<T> extends AbstractArgumentBinder<T> implements AnnotatedRequestArgumentBinder<Part, T> {
+    private final CompletedFileUploadBinder completedFileUploadBinder;
+
+    public PartAnnotationRequestArgumentBinder(ConversionService conversionService, CompletedFileUploadBinder completedFileUploadBinder) {
+        super(conversionService);
+        this.completedFileUploadBinder = completedFileUploadBinder;
+    }
+
+    @Override
+    public Class<Part> getAnnotationType() {
+        return Part.class;
+    }
+
+    @Override
+    public BindingResult<T> bind(ArgumentConversionContext<T> context, HttpRequest<?> source) {
+        if (!(source instanceof ApiGatewayServletRequest)) {
+            return BindingResult.UNSATISFIED;
+        }
+
+        ApiGatewayServletRequest<?, ?, ?> request = (ApiGatewayServletRequest<?, ?, ?>) source;
+
+        if (completedFileUploadBinder.matches(context.getArgument().getType())) {
+            return completedFileUploadBinder.bind((ArgumentConversionContext) context, request);
+        }
+
+        Argument<T> argument = context.getArgument();
+        String inputName = argument.getAnnotationMetadata().stringValue(Bindable.NAME).orElse(argument.getName());
+
+        return () -> conversionService.convert(request.getParameters().get(inputName), context);
+    }
+}

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/SimpleCompletedFileUpload.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/multipart/SimpleCompletedFileUpload.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy.multipart;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.http.MediaType;
+import io.micronaut.http.multipart.CompletedFileUpload;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * A simple implementation of {@link CompletedFileUpload} for use with API Gateway requests.
+ */
+class SimpleCompletedFileUpload implements CompletedFileUpload {
+    private final String name;
+    private final String filename;
+    private final MediaType contentType;
+    private final byte[] content;
+    private final long size;
+
+    /**
+     * Constructs a new SimpleCompletedFileUpload.
+     *
+     * @param name The name of the file field
+     * @param filename The client-side filename
+     * @param contentType The content type as a string
+     * @param content The file content as bytes
+     */
+    public SimpleCompletedFileUpload(
+            @NonNull String name,
+            @NonNull String filename,
+            @Nullable String contentType,
+            @NonNull byte[] content) {
+        this.name = name;
+        this.filename = filename;
+        this.contentType = contentType != null ? MediaType.of(contentType) : MediaType.APPLICATION_OCTET_STREAM_TYPE;
+        this.content = content;
+        this.size = content.length;
+    }
+
+    @Override
+    @NonNull
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    @NonNull
+    public String getFilename() {
+        return filename;
+    }
+
+    @Override
+    @NonNull
+    public Optional<MediaType> getContentType() {
+        return Optional.of(contentType);
+    }
+
+    @Override
+    @NonNull
+    public ByteBuffer getByteBuffer() throws IOException {
+        return ByteBuffer.wrap(content);
+    }
+
+    @Override
+    @NonNull
+    public InputStream getInputStream() throws IOException {
+        return new ByteArrayInputStream(content);
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public long getDefinedSize() {
+        return size;
+    }
+
+    @Override
+    @NonNull
+    public byte[] getBytes() throws IOException {
+        return content;
+    }
+
+    @Override
+    public boolean isComplete() {
+        return true;
+    }
+
+    @Override
+    public void discard() {
+        // No resources to release - data is held in memory
+    }
+}


### PR DESCRIPTION
Hi there! This is a change to add support for multipart form uploads, e.g. file uploads. The `Serverless Function` mode already supports file uploads, but if you want to use them in your controllers (`Application` mode), we need something like this.

Previously, this module was using the query string decoder on the body for multipart uploads, which isn't right -- multipart form bodies have their own crazy syntax.

This adds support to the base ApiGatewayServletRequest for multipart/form-data requests and argument bindings for:
* `@Part String name` (binding to a part of name `name`)
* `@Part("foo") String name`
* `@Part("file") CompletedFileUpload file`

This does NOT add support for:
* Streaming file uploads (which I'm not sure we can easily support anyway)

This change is currently missing:
* Unit tests for the new classes
* Integration tests (?) for handling API Gateway events containing file uploads.
  * If this is something we need, I'd appreciate any pointers you have on how to implement this.

I've created a simple test project that can verify this works and can provide if there's interest.

Looking for feedback and direction on things that need to be implemented before this can be merged. Thanks!
* Feedback on thread safety
* Feedback on whether there's a better way to store file uploads -- they don't exactly fit in the parameters map, which is a String map.
* Feedback on class visibility, package structure, annotations

Closes #270.