### PR TITLE
update micronaut to 4.9.12 to fix Netty CVE

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "4.9.4"
+micronaut = "4.9.12"
 micronaut-docs = "2.0.0"
 micronaut-test = "4.8.0"
 groovy = "4.0.26"


### PR DESCRIPTION
CVE-2025-55163 CVE-2025-58056 and CVE-2025-58057