### PR TITLE
fixes for payload v2 and v1 

### DIFF
--- a/function-aws-api-proxy/build.gradle.kts
+++ b/function-aws-api-proxy/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     compileOnly(mnSecurity.micronaut.security)
     testImplementation(mn.micronaut.jackson.databind)
     testImplementation(mnViews.micronaut.views.handlebars)
-    implementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnTest.micronaut.test.junit5)
     testRuntimeOnly(mnTest.junit.jupiter.engine)
     testAnnotationProcessor(mn.micronaut.inject.java)
 }

--- a/function-aws-api-proxy/build.gradle.kts
+++ b/function-aws-api-proxy/build.gradle.kts
@@ -11,6 +11,9 @@ dependencies {
     compileOnly(mnSecurity.micronaut.security)
     testImplementation(mn.micronaut.jackson.databind)
     testImplementation(mnViews.micronaut.views.handlebars)
+    implementation(mnTest.micronaut.test.junit5)
+    testRuntimeOnly(mnTest.junit.jupiter.engine)
+    testAnnotationProcessor(mn.micronaut.inject.java)
 }
 
 spotless {

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/ApiGatewayServletRequest.java
@@ -370,7 +370,12 @@ public abstract class ApiGatewayServletRequest<T, REQ, RES> implements MutableSe
      */
     @NonNull
     protected MutableHttpHeaders getHeaders(@NonNull Supplier<Map<String, String>> singleHeaders, @NonNull Supplier<Map<String, List<String>>> multiValueHeaders) {
-        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(multiValueHeaders.get(), singleHeaders.get()), conversionService);
+        Map<String, List<String>> multi = multiValueHeaders.get();
+        Map<String, List<String>> values = MapCollapseUtils.collapse(multi, singleHeaders.get());
+        if (CollectionUtils.isNotEmpty(multi)) {
+            return new MultiValueMutableHttpHeaders(values, conversionService);
+        }
+        return new CaseInsensitiveMutableHttpHeaders(values, conversionService);
     }
 
     public static final class EmptyBodyException extends IOException {

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsCookies.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsCookies.java
@@ -49,9 +49,11 @@ public final class AwsCookies implements Cookies {
      */
     public AwsCookies(String path, HttpHeaders headers, ConversionService conversionService) {
         this.conversionService = conversionService;
-        String value = headers.get(HttpHeaders.COOKIE);
-        if (value != null) {
-            List<Cookie> decodeCookies = ServerCookieDecoder.INSTANCE.decode(value);
+        List<String> values = headers.getAll(HttpHeaders.COOKIE);
+        if (!values.isEmpty()) {
+            List<Cookie> decodeCookies = values.stream()
+                .flatMap(value -> ServerCookieDecoder.INSTANCE.decode(value).stream())
+                .toList();
             cookies = new LinkedHashMap<>(decodeCookies.size());
             decodeCookies.stream()
                 .filter(cookie -> cookie.getPath() == null || path.startsWith(cookie.getPath()))

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsCookies.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/AwsCookies.java
@@ -18,6 +18,7 @@ package io.micronaut.function.aws.proxy;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ArgumentConversionContext;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
@@ -50,7 +51,7 @@ public final class AwsCookies implements Cookies {
     public AwsCookies(String path, HttpHeaders headers, ConversionService conversionService) {
         this.conversionService = conversionService;
         List<String> values = headers.getAll(HttpHeaders.COOKIE);
-        if (!values.isEmpty()) {
+        if (CollectionUtils.isNotEmpty(values)) {
             List<Cookie> decodeCookies = values.stream()
                 .flatMap(value -> ServerCookieDecoder.INSTANCE.decode(value).stream())
                 .toList();

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValue.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValue.java
@@ -75,11 +75,17 @@ class MapListOfStringAndMapStringConvertibleMultiValue implements ConvertibleMul
 
     @Override
     public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
-        final String v = get(name);
-        if (v != null) {
-            return conversionService.convert(v, conversionContext);
+        List<String> valuesForName = getAll(name);
+        if (CollectionUtils.isEmpty(valuesForName)) {
+            return Optional.empty();
         }
-        return Optional.empty();
+        Object value = isIterableOrArray(conversionContext) ? valuesForName : valuesForName.get(0);
+        return conversionService.convert(value, conversionContext);
+    }
+
+    private static boolean isIterableOrArray(ArgumentConversionContext<?> conversionContext) {
+        Class<?> type = conversionContext.getArgument().getType();
+        return type.isArray() || Iterable.class.isAssignableFrom(type);
     }
 
     @NonNull

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringMutableHttpParameters.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringMutableHttpParameters.java
@@ -73,10 +73,6 @@ public final class MapListOfStringAndMapStringMutableHttpParameters implements M
 
     @Override
     public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
-        final String v = get(name);
-        if (v != null) {
-            return values.getConversionService().convert(v, conversionContext);
-        }
-        return Optional.empty();
+        return values.get(name, conversionContext);
     }
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MultiValueMutableHttpHeaders.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/MultiValueMutableHttpHeaders.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.function.aws.proxy;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ArgumentConversionContext;
+import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.http.CaseInsensitiveMutableHttpHeaders;
+import io.micronaut.http.MutableHttpHeaders;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Header implementation that preserves multi-value headers for iterable and array conversions.
+ */
+@Internal
+final class MultiValueMutableHttpHeaders implements MutableHttpHeaders {
+
+    private final CaseInsensitiveMutableHttpHeaders delegate;
+    private ConversionService conversionService;
+
+    MultiValueMutableHttpHeaders(Map<String, List<String>> headers, ConversionService conversionService) {
+        this.delegate = new CaseInsensitiveMutableHttpHeaders(headers, conversionService);
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public List<String> getAll(CharSequence name) {
+        return delegate.getAll(name);
+    }
+
+    @Override
+    public String get(CharSequence name) {
+        return delegate.get(name);
+    }
+
+    @Override
+    public Set<String> names() {
+        return delegate.names();
+    }
+
+    @Override
+    public Collection<List<String>> values() {
+        return delegate.values();
+    }
+
+    @Override
+    public <T> Optional<T> get(CharSequence name, ArgumentConversionContext<T> conversionContext) {
+        List<String> valuesForName = getAll(name);
+        if (CollectionUtils.isEmpty(valuesForName)) {
+            return Optional.empty();
+        }
+        Object value = isIterableOrArray(conversionContext) && valuesForName.size() > 1 ? valuesForName : valuesForName.get(0);
+        return conversionService.convert(value, conversionContext);
+    }
+
+    @Override
+    public MutableHttpHeaders add(CharSequence header, CharSequence value) {
+        delegate.add(header, value);
+        return this;
+    }
+
+    @Override
+    public MutableHttpHeaders remove(CharSequence header) {
+        delegate.remove(header);
+        return this;
+    }
+
+    @Override
+    public void setConversionService(ConversionService conversionService) {
+        delegate.setConversionService(conversionService);
+        this.conversionService = conversionService;
+    }
+
+    private static boolean isIterableOrArray(ArgumentConversionContext<?> conversionContext) {
+        Class<?> type = conversionContext.getArgument().getType();
+        return type.isArray() || Iterable.class.isAssignableFrom(type);
+    }
+}

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequest.java
@@ -21,8 +21,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.proxy.ApiGatewayServletRequest;
-import io.micronaut.function.aws.proxy.MapCollapseUtils;
-import io.micronaut.http.CaseInsensitiveMutableHttpHeaders;
 import io.micronaut.http.MutableHttpHeaders;
 import io.micronaut.http.MutableHttpParameters;
 import io.micronaut.servlet.http.BodyBuilder;
@@ -32,8 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Base64;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Implementation of {@link ServletHttpRequest} for AWS API Gateway Proxy.
@@ -82,9 +78,7 @@ public final class ApiGatewayProxyServletRequest<B> extends ApiGatewayServletReq
 
     @Override
     public MutableHttpHeaders getHeaders() {
-        Map<String, List<String>> multiValueHeaders = requestEvent.getMultiValueHeaders();
-        Map<String, String> singleValueHeaders = requestEvent.getHeaders();
-        return new CaseInsensitiveMutableHttpHeaders(MapCollapseUtils.collapse(multiValueHeaders, singleValueHeaders), conversionService);
+        return getHeaders(requestEvent::getHeaders, requestEvent::getMultiValueHeaders);
     }
 
     @Override

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.function.aws.proxy.ApiGatewayServletRequest;
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MutableHttpHeaders;
@@ -90,9 +91,8 @@ public final class APIGatewayV2HTTPEventServletRequest<B> extends ApiGatewayServ
 
     private Map<String, List<String>> getCookieHeaders() {
         List<String> cookies = requestEvent.getCookies();
-        if (cookies == null || cookies.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        return Map.of(HttpHeaders.COOKIE, cookies);
+        return CollectionUtils.isEmpty(cookies)
+            ? Collections.emptyMap()
+            : Map.of(HttpHeaders.COOKIE, cookies);
     }
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventServletRequest.java
@@ -20,6 +20,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.function.aws.proxy.ApiGatewayServletRequest;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.MutableHttpHeaders;
 import io.micronaut.http.MutableHttpParameters;
 import io.micronaut.servlet.http.BodyBuilder;
@@ -29,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Implementation of {@link ServletHttpRequest} for AWS API Gateway Proxy.
@@ -72,7 +75,7 @@ public final class APIGatewayV2HTTPEventServletRequest<B> extends ApiGatewayServ
 
     @Override
     public MutableHttpHeaders getHeaders() {
-        return getHeaders(requestEvent::getHeaders, Collections::emptyMap);
+        return getHeaders(requestEvent::getHeaders, this::getCookieHeaders);
     }
 
     @Override
@@ -83,5 +86,13 @@ public final class APIGatewayV2HTTPEventServletRequest<B> extends ApiGatewayServ
     @Override
     public ServletHttpResponse<APIGatewayV2HTTPResponse, ?> getResponse() {
         return response;
+    }
+
+    private Map<String, List<String>> getCookieHeaders() {
+        List<String> cookies = requestEvent.getCookies();
+        if (cookies == null || cookies.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Map.of(HttpHeaders.COOKIE, cookies);
     }
 }

--- a/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPResponseServletResponse.java
+++ b/function-aws-api-proxy/src/main/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPResponseServletResponse.java
@@ -18,13 +18,16 @@ package io.micronaut.function.aws.proxy.payload2;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
+import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.BinaryTypeConfiguration;
 import io.micronaut.function.aws.proxy.AbstractServletHttpResponse;
 import io.micronaut.function.aws.proxy.MapCollapseUtils;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.servlet.http.ServletHttpResponse;
 
 import java.util.Base64;
+import java.util.List;
 
 /**
  * Implementation of {@link ServletHttpResponse} for AWS API Gateway Proxy.
@@ -46,7 +49,10 @@ public class APIGatewayV2HTTPResponseServletResponse<B> extends AbstractServletH
             .withHeaders(MapCollapseUtils.getSingleValueHeaders(headers))
             .withMultiValueHeaders(MapCollapseUtils.getMultiHeaders(headers))
             .withStatusCode(status);
-
+        List<String> cookies = headers.getAll(HttpHeaders.SET_COOKIE);
+        if (CollectionUtils.isNotEmpty(cookies)) {
+            apiGatewayV2HTTPResponseBuilder.withCookies(cookies);
+        }
         if (binaryTypeConfiguration.isMediaTypeBinary(getHeaders().getContentType().orElse(null))) {
             apiGatewayV2HTTPResponseBuilder
                 .withIsBase64Encoded(true)

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValueSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/MapListOfStringAndMapStringConvertibleMultiValueSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.function.aws.proxy
 
 import io.micronaut.core.convert.ConversionService
+import io.micronaut.core.convert.ConversionContext
 import spock.lang.See
 import spock.lang.Specification
 
@@ -24,6 +25,27 @@ class MapListOfStringAndMapStringConvertibleMultiValueSpec extends Specification
         map.getAll('foo') == ['bar', 'baz']
         map.getAll('FOO') == ['bar', 'baz']
         map.get('foo') == 'bar'
+    }
+
+    void "typed conversion preserves multi values for iterable and array targets"() {
+        given:
+        def multi = ['foo': ['bar', 'baz']]
+        def map = new MapListOfStringAndMapStringConvertibleMultiValue(ConversionService.SHARED, multi, [:])
+
+        expect:
+        map.get('foo', ConversionContext.LIST_OF_STRING).get() == ['bar', 'baz']
+        map.get('foo', ConversionContext.of(String[].class)).get().toList() == ['bar', 'baz']
+        map.get('foo', ConversionContext.STRING).get() == 'bar'
+    }
+
+    void "mutable http parameters typed conversion preserves multi values for iterable targets"() {
+        given:
+        def multi = ['foo': ['bar', 'baz']]
+        def parameters = new MapListOfStringAndMapStringMutableHttpParameters(ConversionService.SHARED, multi, [:])
+
+        expect:
+        parameters.get('foo', ConversionContext.LIST_OF_STRING).get() == ['bar', 'baz']
+        parameters.get('foo', ConversionContext.STRING).get() == 'bar'
     }
 
     void "works with single maps"() {

--- a/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequestSpec.groovy
+++ b/function-aws-api-proxy/src/test/groovy/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyServletRequestSpec.groovy
@@ -1,6 +1,8 @@
 package io.micronaut.function.aws.proxy.payload1
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+import io.micronaut.core.convert.ConversionContext
+import io.micronaut.core.convert.ConversionService
 import io.micronaut.function.aws.proxy.ApiGatewayServletRequest
 import spock.lang.Specification
 
@@ -29,12 +31,14 @@ class ApiGatewayProxyServletRequestSpec extends Specification {
         request.setHttpMethod("GET")
 
         when:
-        ApiGatewayProxyServletRequest servletRequest = new ApiGatewayProxyServletRequest(request, null, null, null)
+        ApiGatewayProxyServletRequest servletRequest = new ApiGatewayProxyServletRequest(request, null, ConversionService.SHARED, null)
 
         then:
         servletRequest
         "Bar" == servletRequest.getHeaders().get("Foo")
         ["Bar"] == servletRequest.getHeaders().getAll("Foo")
         ["value1", "value2", "value3"] == servletRequest.getHeaders().getAll("Key")
+        "value1" == servletRequest.getHeaders().get("Key", ConversionContext.STRING).get()
+        ["value1", "value2", "value3"] == servletRequest.getHeaders().get("Key", ConversionContext.LIST_OF_STRING).get()
     }
 }

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyRequestEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyRequestEventFunctionTest.java
@@ -10,6 +10,7 @@ import io.micronaut.function.aws.proxy.utils.MockContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
@@ -137,6 +138,12 @@ class ApiGatewayProxyRequestEventFunctionTest {
         });
     }
 
+    @Test
+    void body() throws IOException {
+        executeTest("/body", response -> {
+            assertEquals("Hello from Lambda!", response.getBody());
+        });
+    }
     private static void executeTest(String path, Consumer<APIGatewayProxyResponseEvent> responseConsumer) throws IOException {
         Map<String, Object> config = Map.of("micronaut.security.enabled", StringUtils.FALSE, "spec.name", "ApiGatewayProxyRequestEventFunctionTest");
         ApplicationContext ctx = ApplicationContext.builder().properties(config).build();
@@ -154,6 +161,10 @@ class ApiGatewayProxyRequestEventFunctionTest {
     @Requires(property = "spec.name", value = "ApiGatewayProxyRequestEventFunctionTest")
     @Controller
     static class DuplicatedHeadersController {
+        @Post("/body")
+        String body(@Body String body) {
+            return body;
+        }
 
         @Post("/cookies")
         HttpResponse<?> cookies(HttpRequest<?> request) {

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyRequestEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload1/ApiGatewayProxyRequestEventFunctionTest.java
@@ -1,0 +1,183 @@
+package io.micronaut.function.aws.proxy.payload1;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.function.aws.proxy.utils.MockContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.cookie.Cookies;
+import io.micronaut.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ApiGatewayProxyRequestEventFunctionTest {
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
+    private static final String PAYLOAD_V1_JSON = """
+        {
+            "version": "1.0",
+            "resource": "%1$s",
+            "path": "%1$s",
+            "httpMethod": "POST",
+            "headers": {
+              "header1": "value1",
+              "header2": "value2"
+            },
+            "multiValueHeaders": {
+              "header1": [
+                "value1"
+              ],
+              "header2": [
+                "value1",
+                "value2"
+              ]
+            },
+            "queryStringParameters": {
+              "parameter1": "value1",
+              "parameter2": "value"
+            },
+            "multiValueQueryStringParameters": {
+              "parameter1": [
+                "value1",
+                "value2"
+              ],
+              "parameter2": [
+                "value"
+              ]
+            },
+            "requestContext": {
+              "accountId": "123456789012",
+              "apiId": "id",
+              "authorizer": {
+                "claims": null,
+                "scopes": null
+              },
+              "domainName": "id.execute-api.us-east-1.amazonaws.com",
+              "domainPrefix": "id",
+              "extendedRequestId": "request-id",
+              "httpMethod": "POST",
+              "identity": {
+                "accessKey": null,
+                "accountId": null,
+                "caller": null,
+                "cognitoAuthenticationProvider": null,
+                "cognitoAuthenticationType": null,
+                "cognitoIdentityId": null,
+                "cognitoIdentityPoolId": null,
+                "principalOrgId": null,
+                "sourceIp": "192.0.2.1",
+                "user": null,
+                "userAgent": "user-agent",
+                "userArn": null,
+                "clientCert": {
+                  "clientCertPem": "CERT_CONTENT",
+                  "subjectDN": "www.example.com",
+                  "issuerDN": "Example issuer",
+                  "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+                  "validity": {
+                    "notBefore": "May 28 12:30:02 2019 GMT",
+                    "notAfter": "Aug  5 09:36:04 2021 GMT"
+                  }
+                }
+              },
+              "path": "%1$s",
+              "protocol": "HTTP/1.1",
+              "requestId": "id=",
+              "requestTime": "04/Mar/2020:19:15:17 +0000",
+              "requestTimeEpoch": 1583349317135,
+              "resourceId": null,
+              "resourcePath": "/my/path",
+              "stage": "$default"
+            },
+            "pathParameters": null,
+            "stageVariables": null,
+            "body": "Hello from Lambda!",
+            "isBase64Encoded": false
+          }""";
+
+    @Test
+    void multiValueHeadersShouldBeConsidered() throws IOException {
+        executeTest("/duplicatedheaders", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals("""
+        {"header2":["value1","value2"]}""", response.getBody());
+        });
+    }
+
+    @Test
+    void duplicateQueryStringsAreCombinedWithCommas () throws IOException {
+        executeTest("/duplicateQueryStrings", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals("""
+        {"parameter1":["value1","value2"]}""", response.getBody());
+        });
+    }
+
+    @Test
+    void singleValueQueryString() throws IOException {
+        executeTest("/singleValueQueryString", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals("""
+        {"parameter2":["value"]}""", response.getBody());
+        });
+    }
+
+    private static void executeTest(String path, Consumer<APIGatewayProxyResponseEvent> responseConsumer) throws IOException {
+        Map<String, Object> config = Map.of("micronaut.security.enabled", StringUtils.FALSE, "spec.name", "ApiGatewayProxyRequestEventFunctionTest");
+        ApplicationContext ctx = ApplicationContext.builder().properties(config).build();
+        try (ApiGatewayProxyRequestEventFunction handler = new ApiGatewayProxyRequestEventFunction(ctx)) {
+            JsonMapper jsonMapper = ctx.getBean(JsonMapper.class);
+            String json = PAYLOAD_V1_JSON.formatted(path);
+            APIGatewayProxyRequestEvent input = jsonMapper.readValue(json, APIGatewayProxyRequestEvent.class);
+            Context lambdaContext = new MockContext();
+            APIGatewayProxyResponseEvent response = handler.handleRequest(input, lambdaContext);
+            assertNotNull(response);
+            responseConsumer.accept(response);
+        }
+    }
+
+    @Requires(property = "spec.name", value = "ApiGatewayProxyRequestEventFunctionTest")
+    @Controller
+    static class DuplicatedHeadersController {
+
+        @Post("/cookies")
+        HttpResponse<?> cookies(HttpRequest<?> request) {
+            MutableHttpResponse<?> response = HttpResponse.ok();
+            Cookies cookies = request.getCookies();
+            for (Cookie cookie : cookies.getAll()) {
+                response.cookie(Cookie.of(cookie.getName(), cookie.getValue() == null ? "empty" : cookie.getValue()));
+            }
+            return response;
+        }
+
+        @Post("/duplicatedheaders")
+        Map<String, Object> duplicatedHeaders(@Header List<String> header2) {
+            return Map.of("header2", header2);
+        }
+
+        @Post("/duplicateQueryStrings")
+        Map<String, Object> duplicateQueryStrings(@QueryValue List<String> parameter1) {
+            return Map.of("parameter1", parameter1);
+        }
+
+        @Post("/singleValueQueryString")
+        Map<String, Object> singleValueQueryString(@QueryValue List<String> parameter2) {
+            return Map.of("parameter2", parameter2);
+        }
+    }
+}

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -170,7 +170,8 @@ class APIGatewayV2HTTPEventFunctionTest {
             assertEquals(2, cookies.size());
             assertTrue(cookies.contains("cookie1=value1"));
             assertTrue(cookies.contains("cookie2=value2"));
-            assertEquals("cookie1=value1; cookie2=value2", response.getHeaders().get(HttpHeaders.SET_COOKIE));
+            String singleHeader = response.getHeaders().get(HttpHeaders.SET_COOKIE);
+            assertTrue("cookie1=value1".equals(singleHeader) || "cookie2=value2".equals(singleHeader));
         });
     }
 

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -7,6 +7,7 @@ import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.function.aws.proxy.utils.MockContext;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
@@ -154,6 +155,25 @@ class APIGatewayV2HTTPEventFunctionTest {
         }
     }
 
+    @Test
+    void cookieHeaderSingleValueAccessPreservesAllCookies() throws IOException {
+        executeTest("/cookieHeader", response -> {
+            assertEquals("cookie1=value1; cookie2=value2", response.getBody());
+        });
+    }
+
+    @Test
+    void v2ResponseMissesCookieInHeader() throws IOException {
+        executeTest("/cookies", response -> {
+            assertEquals(Set.of("cookie1=value1", "cookie2=value2"), Set.copyOf(response.getCookies()));
+            List<String> cookies = response.getMultiValueHeaders().get(HttpHeaders.SET_COOKIE);
+            assertEquals(2, cookies.size());
+            assertTrue(cookies.contains("cookie1=value1"));
+            assertTrue(cookies.contains("cookie2=value2"));
+            assertEquals("cookie1=value1; cookie2=value2", response.getHeaders().get(HttpHeaders.SET_COOKIE));
+        });
+    }
+
     @Requires(property = "spec.name", value = "APIGatewayV2HTTPEventFunctionTest")
     @Controller
     static class DuplicatedHeadersController {
@@ -185,6 +205,11 @@ class APIGatewayV2HTTPEventFunctionTest {
         @Post("/singleValueQueryString")
         Map<String, Object> singleValueQueryString(@QueryValue List<String> parameter2) {
             return Map.of("parameter2", parameter2);
+        }
+
+        @Post("/cookieHeader")
+        String cookieHeader(@Header(HttpHeaders.COOKIE) String cookieHeader) {
+            return cookieHeader;
         }
     }
 }

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -18,6 +18,7 @@ import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
 import io.micronaut.http.cookie.Cookie;
 import io.micronaut.http.cookie.Cookies;
+import io.micronaut.http.cookie.ServerCookieEncoder;
 import io.micronaut.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
@@ -156,9 +157,18 @@ class APIGatewayV2HTTPEventFunctionTest {
     }
 
     @Test
-    void cookieHeaderSingleValueAccessPreservesAllCookies() throws IOException {
+    void cookieHeaderSingleValueAccessPreservesAllCookiesWhenBindingCookies() throws IOException {
+        executeTest("/cookiesObject", response -> {
+            assertEquals("""
+                ["cookie1=value1","cookie2=value2"]""", response.getBody());
+        });
+    }
+
+    @Test
+    void cookieHeaderSingleValueAccessPreservesAllCookiesWhenBindingToHeader() throws IOException {
         executeTest("/cookieHeader", response -> {
-            assertEquals("cookie1=value1; cookie2=value2", response.getBody());
+            assertEquals("""
+                ["cookie1=value1","cookie2=value2"]""", response.getBody());
         });
     }
 
@@ -178,6 +188,13 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Requires(property = "spec.name", value = "APIGatewayV2HTTPEventFunctionTest")
     @Controller
     static class DuplicatedHeadersController {
+
+        private final ServerCookieEncoder serverCookieEncoder;
+
+        DuplicatedHeadersController() {
+            this.serverCookieEncoder = ServerCookieEncoder.INSTANCE;
+        }
+
         @Post("/body")
         String body(@Body String body) {
             return body;
@@ -206,6 +223,11 @@ class APIGatewayV2HTTPEventFunctionTest {
         @Post("/singleValueQueryString")
         Map<String, Object> singleValueQueryString(@QueryValue List<String> parameter2) {
             return Map.of("parameter2", parameter2);
+        }
+
+        @Post("/cookiesObject")
+        List<String> cookiesObject(Cookies cookies) {
+            return serverCookieEncoder.encode(cookies.get("cookie1"), cookies.get("cookie2"));
         }
 
         @Post("/cookieHeader")

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -1,0 +1,220 @@
+package io.micronaut.function.aws.proxy.payload2;
+
+import com.amazonaws.services.lambda.runtime.ClientContext;
+import com.amazonaws.services.lambda.runtime.CognitoIdentity;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Post;
+import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.json.JsonMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class APIGatewayV2HTTPEventFunctionTest {
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
+    private static String JSON = """
+        {
+          "version": "2.0",
+          "routeKey": "$default",
+          "rawPath": "%1$s",
+          "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
+          "cookies": [
+            "cookie1",
+            "cookie2"
+          ],
+          "headers": {
+            "header1": "value1",
+            "header2": "value1,value2"
+          },
+          "queryStringParameters": {
+            "parameter1": "value1,value2",
+            "parameter2": "value"
+          },
+          "requestContext": {
+            "accountId": "123456789012",
+            "apiId": "api-id",
+            "authentication": {
+              "clientCert": {
+                "clientCertPem": "CERT_CONTENT",
+                "subjectDN": "www.example.com",
+                "issuerDN": "Example issuer",
+                "serialNumber": "a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1:a1",
+                "validity": {
+                  "notBefore": "May 28 12:30:02 2019 GMT",
+                  "notAfter": "Aug  5 09:36:04 2021 GMT"
+                }
+              }
+            },
+            "authorizer": {
+              "jwt": {
+                "claims": {
+                  "claim1": "value1",
+                  "claim2": "value2"
+                },
+                "scopes": [
+                  "scope1",
+                  "scope2"
+                ]
+              }
+            },
+            "domainName": "id.execute-api.us-east-1.amazonaws.com",
+            "domainPrefix": "id",
+            "http": {
+              "method": "POST",
+              "path": "%1$s",
+              "protocol": "HTTP/1.1",
+              "sourceIp": "192.0.2.1",
+              "userAgent": "agent"
+            },
+            "requestId": "id",
+            "routeKey": "$default",
+            "stage": "$default",
+            "time": "12/Mar/2020:19:03:58 +0000",
+            "timeEpoch": 1583348638390
+          },
+          "body": "Hello from Lambda",
+          "pathParameters": {
+            "parameter1": "value1"
+          },
+          "isBase64Encoded": false,
+          "stageVariables": {
+            "stageVariable1": "value1",
+            "stageVariable2": "value2"
+          }
+        }""";
+
+    @Test
+    void duplicateHeadersAreCombinedWithCommas() throws IOException {
+        executeTest("/duplicatedheaders", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals("""
+        {"header2":["value1","value2"]}""", response.getBody());
+        });
+    }
+
+    @Test
+    void duplicateQueryStringsAreCombinedWithCommas () throws IOException {
+        executeTest("/duplicateQueryStrings", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals("""
+        {"parameter1":["value1","value2"]}""", response.getBody());
+        });
+    }
+
+    @Test
+    void singleValueQueryString() throws IOException {
+        executeTest("/singleValueQueryString", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals("""
+        {"parameter2":["value"]}""", response.getBody());
+        });
+    }
+
+    private static void executeTest(String path, Consumer<APIGatewayV2HTTPResponse> responseConsumer) throws IOException {
+        Map<String, Object> config = Map.of("micronaut.security.enabled", StringUtils.FALSE, "spec.name", "APIGatewayV2HTTPEventFunctionTest");
+        ApplicationContext ctx = ApplicationContext.builder().properties(config).build();
+        try (APIGatewayV2HTTPEventFunction handler = new APIGatewayV2HTTPEventFunction(ctx)) {
+            JsonMapper jsonMapper = ctx.getBean(JsonMapper.class);
+            String json = JSON.formatted(path);
+            APIGatewayV2HTTPEvent input = jsonMapper.readValue(json, APIGatewayV2HTTPEvent.class);
+            Context lambdaContext = mockContext();
+            APIGatewayV2HTTPResponse response = handler.handleRequest(input, lambdaContext);
+            assertNotNull(response);
+            responseConsumer.accept(response);
+        }
+    }
+
+    @Requires(property = "spec.name", value = "APIGatewayV2HTTPEventFunctionTest")
+    @Controller
+    static class DuplicatedHeadersController {
+
+        @Post("/duplicatedheaders")
+        Map<String, Object> duplicatedHeaders(@Header List<String> header2) {
+            return Map.of("header2", header2);
+        }
+
+        @Post("/duplicateQueryStrings")
+        Map<String, Object> duplicateQueryStrings(@QueryValue List<String> parameter1) {
+            return Map.of("parameter1", parameter1);
+        }
+
+        @Post("/singleValueQueryString")
+        Map<String, Object> singleValueQueryString(@QueryValue List<String> parameter2) {
+            return Map.of("parameter2", parameter2);
+        }
+    }
+
+    private static Context mockContext() {
+        return new Context() {
+
+            @Override
+            public String getAwsRequestId() {
+                return null;
+            }
+
+            @Override
+            public String getLogGroupName() {
+                return null;
+            }
+
+            @Override
+            public String getLogStreamName() {
+                return null;
+            }
+
+            @Override
+            public String getFunctionName() {
+                return null;
+            }
+
+            @Override
+            public String getFunctionVersion() {
+                return null;
+            }
+
+            @Override
+            public String getInvokedFunctionArn() {
+                return null;
+            }
+
+            @Override
+            public CognitoIdentity getIdentity() {
+                return null;
+            }
+
+            @Override
+            public ClientContext getClientContext() {
+                return null;
+            }
+
+            @Override
+            public int getRemainingTimeInMillis() {
+                return 0;
+            }
+
+            @Override
+            public int getMemoryLimitInMB() {
+                return 0;
+            }
+
+            @Override
+            public LambdaLogger getLogger() {
+                return null;
+            }
+        };
+    }
+
+}

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -1,39 +1,43 @@
 package io.micronaut.function.aws.proxy.payload2;
 
-import com.amazonaws.services.lambda.runtime.ClientContext;
-import com.amazonaws.services.lambda.runtime.CognitoIdentity;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.function.aws.proxy.utils.MockContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.http.cookie.Cookie;
+import io.micronaut.http.cookie.Cookies;
 import io.micronaut.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class APIGatewayV2HTTPEventFunctionTest {
     // https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
-    private static String JSON = """
+    private static final String PAYLOAD_V2_JSON = """
         {
           "version": "2.0",
           "routeKey": "$default",
           "rawPath": "%1$s",
           "rawQueryString": "parameter1=value1&parameter1=value2&parameter2=value",
           "cookies": [
-            "cookie1",
-            "cookie2"
+            "cookie1=value1",
+            "cookie2=value2"
           ],
           "headers": {
             "header1": "value1",
@@ -97,6 +101,14 @@ class APIGatewayV2HTTPEventFunctionTest {
         }""";
 
     @Test
+    void allCookieHeadersInTheRequestAreCombinedWithCommasAndAddedToTheCookiesField() throws IOException {
+        executeTest("/cookies", response -> {
+            assertEquals(200, response.getStatusCode());
+            assertEquals(Set.of("cookie1=value1", "cookie2=value2"), Set.copyOf(response.getCookies()));
+        });
+    }
+
+    @Test
     void duplicateHeadersAreCombinedWithCommas() throws IOException {
         executeTest("/duplicatedheaders", response -> {
             assertEquals(200, response.getStatusCode());
@@ -128,9 +140,9 @@ class APIGatewayV2HTTPEventFunctionTest {
         ApplicationContext ctx = ApplicationContext.builder().properties(config).build();
         try (APIGatewayV2HTTPEventFunction handler = new APIGatewayV2HTTPEventFunction(ctx)) {
             JsonMapper jsonMapper = ctx.getBean(JsonMapper.class);
-            String json = JSON.formatted(path);
+            String json = PAYLOAD_V2_JSON.formatted(path);
             APIGatewayV2HTTPEvent input = jsonMapper.readValue(json, APIGatewayV2HTTPEvent.class);
-            Context lambdaContext = mockContext();
+            Context lambdaContext = new MockContext();
             APIGatewayV2HTTPResponse response = handler.handleRequest(input, lambdaContext);
             assertNotNull(response);
             responseConsumer.accept(response);
@@ -140,6 +152,16 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Requires(property = "spec.name", value = "APIGatewayV2HTTPEventFunctionTest")
     @Controller
     static class DuplicatedHeadersController {
+
+        @Post("/cookies")
+        HttpResponse<?> cookies(HttpRequest<?> request) {
+            MutableHttpResponse<?> response = HttpResponse.ok();
+            Cookies cookies = request.getCookies();
+            for (Cookie cookie : cookies.getAll()) {
+                response.cookie(Cookie.of(cookie.getName(), cookie.getValue() == null ? "empty" : cookie.getValue()));
+            }
+            return response;
+        }
 
         @Post("/duplicatedheaders")
         Map<String, Object> duplicatedHeaders(@Header List<String> header2) {
@@ -156,65 +178,4 @@ class APIGatewayV2HTTPEventFunctionTest {
             return Map.of("parameter2", parameter2);
         }
     }
-
-    private static Context mockContext() {
-        return new Context() {
-
-            @Override
-            public String getAwsRequestId() {
-                return null;
-            }
-
-            @Override
-            public String getLogGroupName() {
-                return null;
-            }
-
-            @Override
-            public String getLogStreamName() {
-                return null;
-            }
-
-            @Override
-            public String getFunctionName() {
-                return null;
-            }
-
-            @Override
-            public String getFunctionVersion() {
-                return null;
-            }
-
-            @Override
-            public String getInvokedFunctionArn() {
-                return null;
-            }
-
-            @Override
-            public CognitoIdentity getIdentity() {
-                return null;
-            }
-
-            @Override
-            public ClientContext getClientContext() {
-                return null;
-            }
-
-            @Override
-            public int getRemainingTimeInMillis() {
-                return 0;
-            }
-
-            @Override
-            public int getMemoryLimitInMB() {
-                return 0;
-            }
-
-            @Override
-            public LambdaLogger getLogger() {
-                return null;
-            }
-        };
-    }
-
 }

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -165,14 +165,6 @@ class APIGatewayV2HTTPEventFunctionTest {
     }
 
     @Test
-    void cookieHeaderSingleValueAccessPreservesAllCookiesWhenBindingToHeader() throws IOException {
-        executeTest("/cookieHeader", response -> {
-            assertEquals("""
-                ["cookie1=value1","cookie2=value2"]""", response.getBody());
-        });
-    }
-
-    @Test
     void v2ResponseMissesCookieInHeader() throws IOException {
         executeTest("/cookies", response -> {
             assertEquals(Set.of("cookie1=value1", "cookie2=value2"), Set.copyOf(response.getCookies()));
@@ -228,11 +220,6 @@ class APIGatewayV2HTTPEventFunctionTest {
         @Post("/cookiesObject")
         List<String> cookiesObject(Cookies cookies) {
             return serverCookieEncoder.encode(cookies.get("cookie1"), cookies.get("cookie2"));
-        }
-
-        @Post("/cookieHeader")
-        String cookieHeader(@Header(HttpHeaders.COOKIE) String cookieHeader) {
-            return cookieHeader;
         }
     }
 }

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -10,6 +10,7 @@ import io.micronaut.function.aws.proxy.utils.MockContext;
 import io.micronaut.http.HttpRequest;
 import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.http.annotation.Body;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Header;
 import io.micronaut.http.annotation.Post;
@@ -103,7 +104,6 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Test
     void allCookieHeadersInTheRequestAreCombinedWithCommasAndAddedToTheCookiesField() throws IOException {
         executeTest("/cookies", response -> {
-            assertEquals(200, response.getStatusCode());
             assertEquals(Set.of("cookie1=value1", "cookie2=value2"), Set.copyOf(response.getCookies()));
         });
     }
@@ -111,7 +111,6 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Test
     void duplicateHeadersAreCombinedWithCommas() throws IOException {
         executeTest("/duplicatedheaders", response -> {
-            assertEquals(200, response.getStatusCode());
             assertEquals("""
         {"header2":["value1","value2"]}""", response.getBody());
         });
@@ -120,7 +119,6 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Test
     void duplicateQueryStringsAreCombinedWithCommas () throws IOException {
         executeTest("/duplicateQueryStrings", response -> {
-            assertEquals(200, response.getStatusCode());
             assertEquals("""
         {"parameter1":["value1","value2"]}""", response.getBody());
         });
@@ -129,9 +127,15 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Test
     void singleValueQueryString() throws IOException {
         executeTest("/singleValueQueryString", response -> {
-            assertEquals(200, response.getStatusCode());
             assertEquals("""
         {"parameter2":["value"]}""", response.getBody());
+        });
+    }
+
+    @Test
+    void body() throws IOException {
+        executeTest("/body", response -> {
+            assertEquals("Hello from Lambda", response.getBody());
         });
     }
 
@@ -144,6 +148,7 @@ class APIGatewayV2HTTPEventFunctionTest {
             APIGatewayV2HTTPEvent input = jsonMapper.readValue(json, APIGatewayV2HTTPEvent.class);
             Context lambdaContext = new MockContext();
             APIGatewayV2HTTPResponse response = handler.handleRequest(input, lambdaContext);
+            assertEquals(200, response.getStatusCode());
             assertNotNull(response);
             responseConsumer.accept(response);
         }
@@ -152,6 +157,10 @@ class APIGatewayV2HTTPEventFunctionTest {
     @Requires(property = "spec.name", value = "APIGatewayV2HTTPEventFunctionTest")
     @Controller
     static class DuplicatedHeadersController {
+        @Post("/body")
+        String body(@Body String body) {
+            return body;
+        }
 
         @Post("/cookies")
         HttpResponse<?> cookies(HttpRequest<?> request) {

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/payload2/APIGatewayV2HTTPEventFunctionTest.java
@@ -165,6 +165,14 @@ class APIGatewayV2HTTPEventFunctionTest {
     }
 
     @Test
+    void cookieHeaderSingleValueAccessPreservesAllCookiesWhenBindingToHeader() throws IOException {
+        executeTest("/cookieHeader", response -> {
+            assertEquals("""
+                ["cookie1=value1","cookie2=value2"]""", response.getBody());
+        });
+    }
+
+    @Test
     void v2ResponseMissesCookieInHeader() throws IOException {
         executeTest("/cookies", response -> {
             assertEquals(Set.of("cookie1=value1", "cookie2=value2"), Set.copyOf(response.getCookies()));
@@ -220,6 +228,11 @@ class APIGatewayV2HTTPEventFunctionTest {
         @Post("/cookiesObject")
         List<String> cookiesObject(Cookies cookies) {
             return serverCookieEncoder.encode(cookies.get("cookie1"), cookies.get("cookie2"));
+        }
+
+        @Post("/cookieHeader")
+        List<String> cookieHeader(HttpRequest<?> request) {
+            return request.getHeaders().getAll(HttpHeaders.COOKIE);
         }
     }
 }

--- a/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/utils/MockContext.java
+++ b/function-aws-api-proxy/src/test/java/io/micronaut/function/aws/proxy/utils/MockContext.java
@@ -1,0 +1,63 @@
+package io.micronaut.function.aws.proxy.utils;
+
+import com.amazonaws.services.lambda.runtime.ClientContext;
+import com.amazonaws.services.lambda.runtime.CognitoIdentity;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+
+public class MockContext implements Context {
+    @Override
+    public String getAwsRequestId() {
+        return null;
+    }
+
+    @Override
+    public String getLogGroupName() {
+        return null;
+    }
+
+    @Override
+    public String getLogStreamName() {
+        return null;
+    }
+
+    @Override
+    public String getFunctionName() {
+        return null;
+    }
+
+    @Override
+    public String getFunctionVersion() {
+        return null;
+    }
+
+    @Override
+    public String getInvokedFunctionArn() {
+        return null;
+    }
+
+    @Override
+    public CognitoIdentity getIdentity() {
+        return null;
+    }
+
+    @Override
+    public ClientContext getClientContext() {
+        return null;
+    }
+
+    @Override
+    public int getRemainingTimeInMillis() {
+        return 0;
+    }
+
+    @Override
+    public int getMemoryLimitInMB() {
+        return 0;
+    }
+
+    @Override
+    public LambdaLogger getLogger() {
+        return null;
+    }
+}


### PR DESCRIPTION
https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.proxy-format
> Duplicate query strings are combined with commas and included in the queryStringParameters field.