### PR TITLE
 Fix duplicate embedded server startup for lambda_java runtime

### DIFF
--- a/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/EmbeddedServerFactory.java
+++ b/function-aws-api-proxy-test/src/main/java/io/micronaut/function/aws/proxy/test/EmbeddedServerFactory.java
@@ -21,11 +21,13 @@ import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.ApplicationContextProvider;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.env.Environment;
 import io.micronaut.context.env.PropertySource;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.Experimental;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.util.StringUtils;
+import io.micronaut.function.aws.MicronautLambdaContext;
 import io.micronaut.function.aws.proxy.payload2.APIGatewayV2HTTPEventFunction;
 import jakarta.inject.Named;
 import jakarta.inject.Singleton;
@@ -34,12 +36,14 @@ import jakarta.inject.Singleton;
 @Internal
 @Requires(property = "micronaut.function.aws.proxy.test.enabled", notEquals = StringUtils.FALSE)
 @Factory
+@Requires(notEnv = Environment.FUNCTION)
 class EmbeddedServerFactory {
 
     @Named("HttpServer")
     @Singleton
     ApplicationContextProvider httpServerApplicationContextProvider(ApplicationContext applicationContext) {
-        ApplicationContextBuilder builder = ApplicationContext.builder();
+        ApplicationContextBuilder builder = ApplicationContext.builder()
+            .environments(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA);
         for (PropertySource propertySource : applicationContext.getEnvironment().getPropertySources()) {
             builder = builder.propertySources(propertySource);
         }

--- a/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServerSpec.groovy
+++ b/function-aws-api-proxy-test/src/test/groovy/io/micronaut/function/aws/proxy/test/AwsApiProxyTestServerSpec.groovy
@@ -1,5 +1,12 @@
 package io.micronaut.function.aws.proxy.test
 
+import com.sun.net.httpserver.HttpServer
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.ApplicationContextProvider
+import io.micronaut.context.annotation.Property
+import io.micronaut.context.env.Environment
+import io.micronaut.function.aws.MicronautLambdaContext
+import io.micronaut.function.aws.proxy.payload2.APIGatewayV2HTTPEventFunction
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpResponse
 import io.micronaut.http.HttpStatus
@@ -12,19 +19,40 @@ import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
 import io.micronaut.http.uri.UriBuilder
+import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import spock.lang.Issue
 import spock.lang.Specification
 
 import jakarta.inject.Inject
+import jakarta.inject.Named
 
 import java.nio.charset.StandardCharsets
 
 @MicronautTest
+@Property(name = 'micronaut.server.port', value = '18111')
 class AwsApiProxyTestServerSpec extends Specification {
     @Inject
     @Client('/')
     HttpClient client
+
+    @Inject
+    @Named('HttpServer')
+    ApplicationContextProvider applicationContextProvider
+
+    void 'nested Lambda context does not create an embedded server'() {
+        expect:
+        applicationContextProvider instanceof APIGatewayV2HTTPEventFunction
+
+        when:
+        ApplicationContext lambdaContext = applicationContextProvider.applicationContext
+
+        then:
+        lambdaContext.environment.activeNames.contains(Environment.FUNCTION)
+        lambdaContext.environment.activeNames.contains(MicronautLambdaContext.ENVIRONMENT_LAMBDA)
+        !lambdaContext.containsBean(EmbeddedServer)
+        !lambdaContext.containsBean(HttpServer)
+    }
 
     void 'test invoke function via server'() {
         when:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-micronaut = "5.1.3"
+micronaut = "5.1.5"
 micronaut-test = "5.0.1"
 
 bouncycastle = '1.70'
@@ -8,7 +8,7 @@ logback-json-classic = '0.1.5'
 
 micronaut-discovery = "5.0.0"
 micronaut-groovy = "5.0.0"
-micronaut-logging = "2.0.0"
+micronaut-logging = "2.0.1"
 micronaut-mongodb = "6.0.1"
 micronaut-reactor = "4.1.0"
 micronaut-serde = "3.0.0"


### PR DESCRIPTION
 Closes : #2511 

  `EmbeddedServerFactory` creates a nested Lambda application context for the AWS API Gateway proxy test server. After the JDK HTTP server change, that nested context could also load
  `EmbeddedServerFactory`, causing a second `HttpServerEmbeddedServer` to be created and bound to the same port.

  This change marks `EmbeddedServerFactory` as unavailable in the `function` environment and explicitly creates the nested Lambda context with the `function` and `lambda` environments. As a result,
  the outer local server still starts normally, while the nested Lambda handler context does not create another embedded server.

  A regression test now starts the proxy test server on a fixed port and verifies that the nested Lambda context does not contain an `EmbeddedServer` or JDK `HttpServer`.

  Verified with:

  - `./gradlew --no-daemon :micronaut-function-aws-api-proxy-test:test`
  - Published the affected modules to Maven local and confirmed a generated Micronaut `runtime("lambda_java")` app starts with `./gradlew run`
