### PR TITLE
Fix CloudWatch logging for Picocli applications

### DIFF
--- a/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppender.java
+++ b/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppender.java
@@ -240,6 +240,10 @@ public final class CloudWatchLoggingAppender extends AppenderBase<ILoggingEvent>
             streamName = CloudWatchLoggingClient.getHost();
         }
 
+        if (groupName == null || streamName == null) {
+            return false;
+        }
+
         if (createGroupAndStream) {
             CreateLogGroupRequest createLogGroupRequest = CreateLogGroupRequest.builder().logGroupName(groupName).build();
             try {

--- a/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
+++ b/aws-cloudwatch-logging/src/main/java/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingClient.java
@@ -54,6 +54,7 @@ final class CloudWatchLoggingClient implements ApplicationEventListener<ServerSt
     public CloudWatchLoggingClient(CloudWatchLogsClient logging, ApplicationConfiguration applicationConfiguration) {
         this.internalLogging = logging;
         this.internalAppName = applicationConfiguration.getName().orElse("");
+        setLogging(logging, null, internalAppName);
     }
 
     static synchronized boolean isReady() {

--- a/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
+++ b/aws-cloudwatch-logging/src/test/groovy/io/micronaut/aws/cloudwatch/logging/CloudWatchLoggingAppenderSpec.groovy
@@ -220,6 +220,29 @@ class CloudWatchLoggingAppenderSpec extends Specification {
         cloudWatchLogsClient.putLogsRequestList.get(0).logStreamName() == "testStream"
     }
 
+    void 'test logging before server startup with custom group and stream names'() {
+        given:
+        LoggingEvent event = createEvent("name", Level.INFO, "testMessage", System.currentTimeMillis())
+        def config = Stub(ApplicationConfiguration) {
+            getName() >> Optional.of("my-awesome-app")
+        }
+        CloudWatchLoggingClient.destroy()
+        new CloudWatchLoggingClient(cloudWatchLogsClient, config)
+
+        when:
+        appender.groupName = "testGroup"
+        appender.streamName = "testStream"
+        appender.start()
+        appender.doAppend(event)
+
+        then:
+        new PollingConditions(timeout: 10, initialDelay: 1.5, factor: 1.25).eventually {
+            cloudWatchLogsClient.putLogsRequestList.size() == 1
+        }
+        cloudWatchLogsClient.putLogsRequestList.get(0).logGroupName() == "testGroup"
+        cloudWatchLogsClient.putLogsRequestList.get(0).logStreamName() == "testStream"
+    }
+
     void 'custom groupName and StreamName'() {
         given:
         def testGroup = "testGroup"

--- a/src/main/docs/guide/sdkv2/cloudWatchLogging/setCloudWatchLogging.adoc
+++ b/src/main/docs/guide/sdkv2/cloudWatchLogging/setCloudWatchLogging.adoc
@@ -1,6 +1,8 @@
 By default, Micronaut application will try to create the group and stream for you using AWS client. To disable this behavior you have to set the `createGroupAndStream` flag to `false` inside your appender.
 Default value for group name is your application name and for stream name is your hostname. If you want you can change them by setting value `groupName` for group name and `streamName` for stream name.
 
+For applications that do not start an embedded server, such as Picocli CLI applications, configure `streamName` explicitly.
+
 .Configurable CloudWatchLoggingAppender Appender Properties
 |===
 |Property|Type|Default value|Description


### PR DESCRIPTION
 Fixes #2478

  Initialize the CloudWatch logging client when its Micronaut bean is created, rather than waiting exclusively for `ServerStartupEvent`.

  Picocli applications start a plain `ApplicationContext` and do not emit `ServerStartupEvent`, which previously left the CloudWatch appender permanently unready and prevented log delivery.

  The server startup listener is retained to resolve the default stream name for embedded-server applications. The appender now defers dispatch when a default group or stream name has not yet been resolved,
  while allowing CLI applications with explicit `groupName` and `streamName` configuration to publish logs.

  Added:
  - A regression test covering logging before server startup with explicit group and stream names.

  Tested with:

  ./gradlew --no-daemon :micronaut-aws-cloudwatch-logging:test
