### PR TITLE
Guard AWS CRT beans on the optional async CRT client

### DIFF
--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/crt/AwsCrtClientFactory.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/crt/AwsCrtClientFactory.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.context.annotation.Prototype;
+import io.micronaut.context.annotation.Requires;
 import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -37,6 +38,7 @@ import software.amazon.awssdk.http.crt.ProxyConfiguration;
 @Factory
 @BootstrapContextCompatible
 @Internal
+@Requires(classes = {AwsCrtHttpClient.class, AwsCrtAsyncHttpClient.class})
 class AwsCrtClientFactory {
     /**
      * The AWS SDK HTTP service implementation class for the AWS CRT HTTP client.

--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/crt/package-info.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/crt/package-info.java
@@ -19,8 +19,12 @@
  * @since 5.1.0
  */
 @NullMarked
+@Requires(classes = {AwsCrtHttpClient.class, AwsCrtAsyncHttpClient.class})
 @Configuration
 package io.micronaut.aws.sdk.v2.client.crt;
 
 import io.micronaut.context.annotation.Configuration;
+import io.micronaut.context.annotation.Requires;
 import org.jspecify.annotations.NullMarked;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
+import software.amazon.awssdk.http.crt.AwsCrtHttpClient;

--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/crt/package-info.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/crt/package-info.java
@@ -19,11 +19,8 @@
  * @since 5.1.0
  */
 @NullMarked
-@Requires(classes = AwsCrtHttpClient.class)
 @Configuration
 package io.micronaut.aws.sdk.v2.client.crt;
 
 import io.micronaut.context.annotation.Configuration;
-import io.micronaut.context.annotation.Requires;
 import org.jspecify.annotations.NullMarked;
-import software.amazon.awssdk.http.crt.AwsCrtHttpClient;

--- a/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/client/crt/AwsCrtOptionalDependencySpec.groovy
+++ b/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/client/crt/AwsCrtOptionalDependencySpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.aws.sdk.v2.client.crt
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import spock.lang.Specification
 
@@ -18,5 +19,14 @@ class AwsCrtOptionalDependencySpec extends Specification {
         then:
         metadata.getAnnotationValuesByType(Requires)
             .any { it.annotationClassValues('classes')*.name as Set == expectedClasses }
+    }
+
+    def "does not load the optional CRT configuration without the CRT dependency"() {
+        when:
+        def context = ApplicationContext.run()
+        then:
+        noExceptionThrown()
+        cleanup:
+        context?.close()
     }
 }

--- a/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/client/crt/AwsCrtOptionalDependencySpec.groovy
+++ b/aws-sdk-v2/src/test/groovy/io/micronaut/aws/sdk/v2/client/crt/AwsCrtOptionalDependencySpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.aws.sdk.v2.client.crt
+
+import io.micronaut.context.annotation.Requires
+import spock.lang.Specification
+
+class AwsCrtOptionalDependencySpec extends Specification {
+
+    def "guards every CRT bean definition on both optional CRT clients"() {
+        when:
+        def definitionClass = Class.forName(
+            'io.micronaut.aws.sdk.v2.client.crt.$AwsCrtClientFactory$Definition'
+        )
+        def metadata = definitionClass.getField('$ANNOTATION_METADATA').get(null)
+        def expectedClasses = [
+            'software.amazon.awssdk.http.crt.AwsCrtHttpClient',
+            'software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient'
+        ] as Set
+        then:
+        metadata.getAnnotationValuesByType(Requires)
+            .any { it.annotationClassValues('classes')*.name as Set == expectedClasses }
+    }
+}


### PR DESCRIPTION
The AWS CRT factory is an optional integration, but its generated bean definitions reference both the synchronous and asynchronous CRT clients. Guarding only package configuration does not propagate the condition to those generated factory definitions, so native startup can resolve a missing optional async CRT type.

This moves the condition onto AwsCrtClientFactory, where Micronaut applies it to every generated factory bean definition. The regression test inspects the generated definition metadata and verifies both optional CRT classes are required; it fails when the factory annotation is removed.

Tests: ./gradlew :micronaut-aws-sdk-v2:test --no-daemon (50 tests).