### PR TITLE
Enable refresh endpoint in HTTP server TCK tests

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.aws.http-server-tck-module.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.aws.http-server-tck-module.gradle
@@ -16,6 +16,7 @@ dependencies {
     testImplementation(mnTest.junit.jupiter.engine)
     testRuntimeOnly(mnLogging.logback.classic)
 
+    testRuntimeOnly(mn.micronaut.management)
     testRuntimeOnly(mnValidation.micronaut.validation)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -115,3 +115,4 @@ testcontainers-localstack = { module = "org.testcontainers:testcontainers-locals
 testcontainers-junit = { module = "org.testcontainers:testcontainers-junit-jupiter" }
 testcontainers-spock = { module = "org.testcontainers:testcontainers-spock" }
 testcontainers-mongodb = { module = "org.testcontainers:testcontainers-mongodb" }
+testcontainers-floci = { module = "io.floci:testcontainers-floci", version = "2.15.0" }

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-alb/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-alb/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
@@ -35,7 +35,6 @@ public class GatewayLambdaServerUnderTest implements ServerUnderTest {
     public GatewayLambdaServerUnderTest(Map<String, Object> properties) {
         properties.put("micronaut.server.context-path", "/");
         properties.put("endpoints.health.service-ready-indicator-enabled", StringUtils.FALSE);
-        properties.put("endpoints.refresh.enabled", StringUtils.FALSE);
         properties.put("micronaut.function.aws.proxy.test.enabled", StringUtils.FALSE);
         this.applicationContext = ApplicationContext
             .builder(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, Environment.TEST)

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-alb/src/test/java/io/micronaut/http/server/tck/lambda/tests/ApplicationLoadBalancerTckTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-alb/src/test/java/io/micronaut/http/server/tck/lambda/tests/ApplicationLoadBalancerTckTestSuite.java
@@ -11,6 +11,7 @@ import org.junit.platform.suite.api.SuiteDisplayName;
     "io.micronaut.http.server.tck.lambda.tests"
 })
 @ExcludeClassNamePatterns({
+    "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest",
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
     "io.micronaut.http.server.tck.tests.hateoas.JsonErrorTest",
     "io.micronaut.http.server.tck.tests.hateoas.VndErrorTest",

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
@@ -34,7 +34,6 @@ public class GatewayLambdaServerUnderTest implements ServerUnderTest {
     public GatewayLambdaServerUnderTest(Map<String, Object> properties) {
         properties.put("micronaut.server.context-path", "/");
         properties.put("endpoints.health.service-ready-indicator-enabled", StringUtils.FALSE);
-        properties.put("endpoints.refresh.enabled", StringUtils.FALSE);
         properties.put("micronaut.function.aws.proxy.test.enabled", StringUtils.FALSE);
         ctx = ApplicationContext
             .builder(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, Environment.TEST)

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV1HttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv1/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV1HttpServerTestSuite.java
@@ -8,6 +8,7 @@ import org.junit.platform.suite.api.*;
     "io.micronaut.http.server.tck.lambda.tests"
 })
 @ExcludeClassNamePatterns({
+    "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest",
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
         "io.micronaut.http.server.tck.tests.hateoas.JsonErrorTest",
         "io.micronaut.http.server.tck.tests.hateoas.VndErrorTest",

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/GatewayLambdaServerUnderTest.java
@@ -34,7 +34,6 @@ public class GatewayLambdaServerUnderTest implements ServerUnderTest {
     public GatewayLambdaServerUnderTest(Map<String, Object> properties) {
         properties.put("micronaut.server.context-path", "/");
         properties.put("endpoints.health.service-ready-indicator-enabled", StringUtils.FALSE);
-        properties.put("endpoints.refresh.enabled", StringUtils.FALSE);
         properties.put("micronaut.function.aws.proxy.test.enabled", StringUtils.FALSE);
         ctx = ApplicationContext
             .builder(Environment.FUNCTION, MicronautLambdaContext.ENVIRONMENT_LAMBDA, Environment.TEST)

--- a/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV2HttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-gateway-proxy-payloadv2/src/test/java/io/micronaut/http/server/tck/lambda/tests/FunctionAwsApiGatewayProxyV2HttpServerTestSuite.java
@@ -8,6 +8,7 @@ import org.junit.platform.suite.api.*;
     "io.micronaut.http.server.tck.lambda.tests"
 })
 @ExcludeClassNamePatterns({
+    "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest",
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
     "io.micronaut.http.server.tck.tests.hateoas.JsonErrorTest",
     "io.micronaut.http.server.tck.tests.hateoas.VndErrorTest",

--- a/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-function-aws-api-proxy-test/src/test/java/io/micronaut/http/server/tck/lambda/tests/MicronautLambdaHandlerHttpServerTestSuite.java
@@ -8,6 +8,7 @@ import org.junit.platform.suite.api.*;
     "io.micronaut.http.server.tck.lambda.tests"
 })
 @ExcludeClassNamePatterns({
+    "io.micronaut.http.server.tck.tests.cors.CorsSimpleRequestTest",
     "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest",
     "io.micronaut.http.server.tck.tests.forms.FormsJacksonAnnotationsTest",
     "io.micronaut.http.server.tck.tests.cors.CrossOriginTest", // CrossOriginTest#httHeaderValueAccessControlExposeHeaderValueCanBeSetViaCrossOriginAnnotation fails

--- a/test-suite-s3/build.gradle.kts
+++ b/test-suite-s3/build.gradle.kts
@@ -17,6 +17,6 @@ dependencies {
     testAnnotationProcessor(mn.micronaut.inject.java)
     testImplementation(mn.micronaut.http.client)
     testImplementation(mnTest.junit.jupiter.params)
-    testImplementation(projects.testSuiteUtils)
+    testImplementation(libs.testcontainers.floci)
     testRuntimeOnly(libs.awssdk.url.connection.client)
 }

--- a/test-suite-s3/src/test/java/example/Floci.java
+++ b/test-suite-s3/src/test/java/example/Floci.java
@@ -1,0 +1,25 @@
+package example;
+
+import io.floci.testcontainers.FlociContainer;
+
+import java.net.URI;
+
+final class Floci {
+
+    private static FlociContainer container;
+
+    private Floci() {
+    }
+
+    static synchronized FlociContainer getContainer() {
+        if (container == null) {
+            container = new FlociContainer();
+            container.start();
+        }
+        return container;
+    }
+
+    static URI endpoint(FlociContainer container) {
+        return URI.create(container.getEndpoint());
+    }
+}

--- a/test-suite-s3/src/test/java/example/S3AsyncClientBeanCreatedEventListener.java
+++ b/test-suite-s3/src/test/java/example/S3AsyncClientBeanCreatedEventListener.java
@@ -2,27 +2,27 @@ package example;
 
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
+import io.floci.testcontainers.FlociContainer;
 import jakarta.inject.Singleton;
-import org.testcontainers.localstack.LocalStackContainer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
-import io.micronaut.localstack.testcontainers.Localstack;
 
 @Singleton
 public class S3AsyncClientBeanCreatedEventListener implements BeanCreatedEventListener<S3AsyncClientBuilder> {
 
     @Override
     public S3AsyncClientBuilder onCreated(BeanCreatedEvent<S3AsyncClientBuilder> event) {
-        LocalStackContainer localstack = Localstack.getLocalStackContainer("s3");
+        FlociContainer floci = Floci.getContainer();
         S3AsyncClientBuilder builder = event.getBean();
-        builder.endpointOverride(localstack.getEndpoint())
+        builder.endpointOverride(Floci.endpoint(floci))
             .credentialsProvider(
                 StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())
+                    AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())
                 )
-            ).region(Region.of(localstack.getRegion()));
+            ).region(Region.of(floci.getRegion()))
+            .forcePathStyle(true);
         return builder;
     }
 }

--- a/test-suite-s3/src/test/java/example/S3BucketTest.java
+++ b/test-suite-s3/src/test/java/example/S3BucketTest.java
@@ -8,9 +8,9 @@ import io.micronaut.http.HttpStatus;
 import io.micronaut.http.client.BlockingHttpClient;
 import io.micronaut.http.client.HttpClient;
 import io.micronaut.http.client.annotation.Client;
-import io.micronaut.localstack.testcontainers.Localstack;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
 import io.micronaut.test.support.TestPropertyProvider;
+import io.floci.testcontainers.FlociContainer;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -76,6 +76,11 @@ class S3BucketTest implements TestPropertyProvider {
 
     @Override
     public @NonNull Map<String, String> getProperties() {
-        return Localstack.getProperties();
+        FlociContainer floci = Floci.getContainer();
+        return Map.of(
+            "aws.access-key-id", floci.getAccessKey(),
+            "aws.secret-key", floci.getSecretKey(),
+            "aws.region", floci.getRegion()
+        );
     }
 }

--- a/test-suite-s3/src/test/java/example/S3ClientBeanCreatedEventListener.java
+++ b/test-suite-s3/src/test/java/example/S3ClientBeanCreatedEventListener.java
@@ -2,28 +2,28 @@ package example;
 
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
+import io.floci.testcontainers.FlociContainer;
 import jakarta.inject.Singleton;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
-import org.testcontainers.localstack.LocalStackContainer;
-import io.micronaut.localstack.testcontainers.Localstack;
 
 @Singleton
 public class S3ClientBeanCreatedEventListener implements BeanCreatedEventListener<S3ClientBuilder> {
 
     @Override
     public S3ClientBuilder onCreated(BeanCreatedEvent<S3ClientBuilder> event) {
-        LocalStackContainer localstack = Localstack.getLocalStackContainer("s3");
+        FlociContainer floci = Floci.getContainer();
         S3ClientBuilder builder = event.getBean();
-        builder.endpointOverride(localstack.getEndpoint())
+        builder.endpointOverride(Floci.endpoint(floci))
             .credentialsProvider(
                 StaticCredentialsProvider.create(
-                    AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())
+                    AwsBasicCredentials.create(floci.getAccessKey(), floci.getSecretKey())
                 )
             )
-            .region(Region.of(localstack.getRegion()));
+            .region(Region.of(floci.getRegion()))
+            .forcePathStyle(true);
         return builder;
     }
 }


### PR DESCRIPTION
Add Micronaut Management to the HTTP server TCK test runtime and stop disabling the refresh endpoint in the ALB, payload v1, and payload v2 Lambda test servers. This allows the shared TCK to exercise refresh endpoint behavior across API Gateway proxy variants.