### PR TITLE
Guard Apache SDK client when HTTP implementation is selected

### DIFF
--- a/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/apache/ApacheClientFactory.java
+++ b/aws-sdk-v2/src/main/java/io/micronaut/aws/sdk/v2/client/apache/ApacheClientFactory.java
@@ -42,7 +42,7 @@ public class ApacheClientFactory {
      */
     @Bean(preDestroy = "close")
     @Singleton
-    @Requires(property = UrlConnectionClientFactory.HTTP_SERVICE_IMPL, notEquals = UrlConnectionClientFactory.URL_CONNECTION_SDK_HTTP_SERVICE)
+    @Requires(missingProperty = UrlConnectionClientFactory.HTTP_SERVICE_IMPL)
     public SdkHttpClient apacheClient(ApacheClientConfiguration configuration) {
         return doCreateClient(configuration);
     }

--- a/test-suite-groovy-aws-sdk-v2-http-client-apache4/src/test/groovy/io/micronaut/aws/sdk/v2/client/apache4/ApacheClientSystemPropertySpec.groovy
+++ b/test-suite-groovy-aws-sdk-v2-http-client-apache4/src/test/groovy/io/micronaut/aws/sdk/v2/client/apache4/ApacheClientSystemPropertySpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.aws.sdk.v2.client.apache4
+
+import io.micronaut.aws.sdk.v2.client.urlConnection.UrlConnectionClientFactory
+import io.micronaut.context.ApplicationContext
+import software.amazon.awssdk.http.SdkHttpClient
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class ApacheClientSystemPropertySpec extends Specification {
+
+    @RestoreSystemProperties
+    void "the apache client is created once when selected by the system property"() {
+        given:
+        System.setProperty(UrlConnectionClientFactory.HTTP_SERVICE_IMPL,
+            'software.amazon.awssdk.http.apache.ApacheSdkHttpService')
+        ApplicationContext applicationContext = ApplicationContext.run()
+
+        when:
+        SdkHttpClient client = applicationContext.getBean(SdkHttpClient)
+
+        then:
+        client instanceof ApacheHttpClient
+        applicationContext.getBeansOfType(SdkHttpClient).size() == 1
+
+        cleanup:
+        applicationContext.close()
+    }
+}


### PR DESCRIPTION
The default Apache SDK client factory must not activate when another HTTP implementation is selected through the AWS SDK system property. Require the property to be absent so the property-specific factories remain mutually exclusive.

Tests:
`./gradlew :test-suite-groovy-aws-sdk-v2-http-client-apache4:test --tests io.micronaut.aws.sdk.v2.client.apache4.ApacheClientSystemPropertySpec --rerun-tasks --stacktrace`